### PR TITLE
fix: Reduce the frequency of updates when there are no windows

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		D87F23762B66006F0085DC12 /* builds-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23752B66006F0085DC12 /* builds-license */; };
 		D8CA0EEA2B93D6FD00DAE758 /* LifecycleCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CA0EE92B93D6FD00DAE758 /* LifecycleCommands.swift */; };
 		D8CA0EEC2B93E1E800DAE758 /* AccountCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CA0EEB2B93E1E800DAE758 /* AccountCommands.swift */; };
+		D8CA0EEE2B93E5A600DAE758 /* SceneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CA0EED2B93E5A600DAE758 /* SceneModel.swift */; };
+		D8CA0EF02B940BBB00DAE758 /* RefreshScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CA0EEF2B940BBB00DAE758 /* RefreshScheduler.swift */; };
+		D8CA0EF22B94110A00DAE758 /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CA0EF12B94110A00DAE758 /* TimeInterval.swift */; };
+		D8CA0EF42B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CA0EF32B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift */; };
 		D8D413E928043FCD001BA6C0 /* SummaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D413E828043FCD001BA6C0 /* SummaryCell.swift */; };
 		D8D413EB28044062001BA6C0 /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D413EA28044062001BA6C0 /* SummaryView.swift */; };
 		D8D413ED2804539C001BA6C0 /* AddActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D413EC2804539C001BA6C0 /* AddActionView.swift */; };
@@ -78,6 +82,10 @@
 		D89E58172B65D2AA0027EB4E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D8CA0EE92B93D6FD00DAE758 /* LifecycleCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleCommands.swift; sourceTree = "<group>"; };
 		D8CA0EEB2B93E1E800DAE758 /* AccountCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCommands.swift; sourceTree = "<group>"; };
+		D8CA0EED2B93E5A600DAE758 /* SceneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneModel.swift; sourceTree = "<group>"; };
+		D8CA0EEF2B940BBB00DAE758 /* RefreshScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshScheduler.swift; sourceTree = "<group>"; };
+		D8CA0EF12B94110A00DAE758 /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
+		D8CA0EF32B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestsHigherFrequencyUpdates.swift; sourceTree = "<group>"; };
 		D8D413E828043FCD001BA6C0 /* SummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryCell.swift; sourceTree = "<group>"; };
 		D8D413EA28044062001BA6C0 /* SummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryView.swift; sourceTree = "<group>"; };
 		D8D413EC2804539C001BA6C0 /* AddActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddActionView.swift; sourceTree = "<group>"; };
@@ -142,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				D81251BC2B92A39C001F6E85 /* HandlesAuthentication.swift */,
+				D8CA0EF32B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -150,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				D8D413FC28047B85001BA6C0 /* Bundle.swift */,
+				D8CA0EF12B94110A00DAE758 /* TimeInterval.swift */,
 				D8355DD127F674F20091BAFD /* URL.swift */,
 			);
 			path = Extensions;
@@ -184,6 +194,8 @@
 				D8355DCE27F63B680091BAFD /* GitHub.swift */,
 				D8F0CE0427F89A8100F4EC83 /* GitHubClient.swift */,
 				D8EE7DD02B7F341800A3DCF0 /* Legal.swift */,
+				D8CA0EEF2B940BBB00DAE758 /* RefreshScheduler.swift */,
+				D8CA0EED2B93E5A600DAE758 /* SceneModel.swift */,
 				D81251B52B918472001F6E85 /* SummaryState.swift */,
 			);
 			path = Model;
@@ -411,7 +423,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8355DD227F674F20091BAFD /* URL.swift in Sources */,
+				D8CA0EF02B940BBB00DAE758 /* RefreshScheduler.swift in Sources */,
 				D8D413F328045535001BA6C0 /* Action.swift in Sources */,
+				D8CA0EEE2B93E5A600DAE758 /* SceneModel.swift in Sources */,
 				D8D413EB28044062001BA6C0 /* SummaryView.swift in Sources */,
 				D8D413E928043FCD001BA6C0 /* SummaryCell.swift in Sources */,
 				D8CA0EEA2B93D6FD00DAE758 /* LifecycleCommands.swift in Sources */,
@@ -429,8 +443,10 @@
 				D866F250280350BC00FC6EBB /* PhoneSettingsView.swift in Sources */,
 				D81251B42B9181E9001F6E85 /* SummaryContentView.swift in Sources */,
 				D8355DCF27F63B680091BAFD /* GitHub.swift in Sources */,
+				D8CA0EF22B94110A00DAE758 /* TimeInterval.swift in Sources */,
 				D8092F012B69A4B100FD21C8 /* AddActionModel.swift in Sources */,
 				D8D413FD28047B85001BA6C0 /* Bundle.swift in Sources */,
+				D8CA0EF42B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift in Sources */,
 				D8D413EF280454AA001BA6C0 /* ApplicationModel.swift in Sources */,
 				D81251BA2B929B27001F6E85 /* MainWindow.swift in Sources */,
 				D8CA0EEC2B93E1E800DAE758 /* AccountCommands.swift in Sources */,

--- a/Builds/BuildsApp.swift
+++ b/Builds/BuildsApp.swift
@@ -42,7 +42,8 @@ struct BuildsApp: App {
 
 #if os(macOS)
 
-        SummaryWindow(applicationModel: applicationModel)
+        SummaryWindow()
+            .environmentObject(applicationModel)
 
         About(Legal.contents)
 

--- a/Builds/Extensions/TimeInterval.swift
+++ b/Builds/Extensions/TimeInterval.swift
@@ -18,29 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-import Diligence
-import Interact
+extension TimeInterval {
 
-struct MainWindow: Scene {
-
-    static let id = "main"
-
-    @EnvironmentObject var applicationModel: ApplicationModel
-    @State var error: Error? = nil
-
-    var body: some Scene {
-        WindowGroup(id: Self.id) {
-            ContentView(applicationModel: applicationModel)
-                .handlesAuthentication()
-                .handlesExternalEvents(preferring: [], allowing: [.main])
-        }
-        .defaultSize(CGSize(width: 800, height: 720))
-        .commands {
-            ToolbarCommands()
-        }
-        .handlesExternalEvents(matching: [.main, .auth])
+    static func minutes(_ minutes: Double) -> TimeInterval {
+        return 60 * minutes
     }
 
 }

--- a/Builds/Model/ApplicationModel.swift
+++ b/Builds/Model/ApplicationModel.swift
@@ -153,6 +153,13 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
 
         // Update the state whenever a user changes the favorites.
         $actions
+            .combineLatest($authenticationToken)
+            .compactMap { (actions, token) -> [Action]? in
+                guard token != nil else {
+                    return nil
+                }
+                return actions
+            }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 Task {
@@ -219,6 +226,7 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
 
     @MainActor func logOut() {
         authenticationToken = nil
+        cachedStatus = [:]
     }
 
     @MainActor func managePermissions() {

--- a/Builds/Model/RefreshScheduler.swift
+++ b/Builds/Model/RefreshScheduler.swift
@@ -1,0 +1,111 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+class RefreshScheduler {
+
+    private let syncQueue = DispatchQueue(label: "TaskScheduler.syncQueue")
+    private let perform: () async -> TimeInterval?
+    private var activeTask: Task<(), Never>? = nil  // Synchronized on syncQueue.
+    private var timer: DispatchSourceTimer? = nil  // Synchornized on syncQueue.
+
+    init(_ perform: @escaping () async -> TimeInterval?) {
+        self.perform = perform
+    }
+
+    func start() {
+        Task {
+            await self.run()
+        }
+    }
+
+    private func scheduledTimer(timeInterval: TimeInterval) -> DispatchSourceTimer {
+        print("Scheduling next refresh in \(timeInterval)s")
+        let timer = DispatchSource.makeTimerSource(queue: syncQueue)
+        timer.schedule(deadline: .now() + timeInterval, repeating: .never)
+        timer.setEventHandler { [weak self] in
+            _ = self?.syncQueue_scheduledTask()
+        }
+        timer.activate()
+        return timer
+    }
+
+    private func syncQueue_scheduledTask() -> Task<(), Never> {
+        dispatchPrecondition(condition: .onQueue(syncQueue))
+
+        // We perform work on the syncQueue to ensure atomicity of activeTask and refreshTimer.
+
+        // If there's already an active task, then we return it to allow the caller to monitor it.
+        if let activeTask = self.activeTask {
+            return activeTask
+        }
+
+        // If there's no active task, then we cancel any scheduled timers to ensure we don't get overlapping tasks.
+        timer?.cancel()
+        timer = nil
+
+        // Next, we create a new task which will perform our operation.
+        // This task is responsible for scheduling the timeout for the ntext task.
+        let activeTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            // Run the task.
+            let timeInterval = await perform()
+
+            // Schedule the next task and clear the current task.
+            syncQueue.async { [weak self] in
+                guard let self else {
+                    return
+                }
+                self.activeTask = nil
+                guard let timeInterval else {
+                    return
+                }
+                self.timer = self.scheduledTimer(timeInterval: timeInterval)
+            }
+        }
+
+        // Update the active task to our newly created task.
+        self.activeTask = activeTask
+        return activeTask
+    }
+
+    func run() async {
+        dispatchPrecondition(condition: .notOnQueue(syncQueue))
+        let task = syncQueue.sync {
+            return self.syncQueue_scheduledTask()
+        }
+        await task.value
+    }
+
+    func cancel() {
+        dispatchPrecondition(condition: .notOnQueue(syncQueue))
+        syncQueue.sync {
+            timer?.cancel()
+            timer = nil
+            activeTask?.cancel()
+            activeTask = nil
+        }
+    }
+
+}

--- a/Builds/Model/SceneModel.swift
+++ b/Builds/Model/SceneModel.swift
@@ -20,27 +20,20 @@
 
 import SwiftUI
 
-import Diligence
 import Interact
 
-struct MainWindow: Scene {
+class SceneModel: ObservableObject, Runnable {
 
-    static let id = "main"
+    let applicationModel: ApplicationModel
 
-    @EnvironmentObject var applicationModel: ApplicationModel
-    @State var error: Error? = nil
+    init(applicationModel: ApplicationModel) {
+        self.applicationModel = applicationModel
+    }
 
-    var body: some Scene {
-        WindowGroup(id: Self.id) {
-            ContentView(applicationModel: applicationModel)
-                .handlesAuthentication()
-                .handlesExternalEvents(preferring: [], allowing: [.main])
-        }
-        .defaultSize(CGSize(width: 800, height: 720))
-        .commands {
-            ToolbarCommands()
-        }
-        .handlesExternalEvents(matching: [.main, .auth])
+    @MainActor func start() {
+    }
+
+    @MainActor func stop() {
     }
 
 }

--- a/Builds/Modifiers/RequestsHigherFrequencyUpdates.swift
+++ b/Builds/Modifiers/RequestsHigherFrequencyUpdates.swift
@@ -20,27 +20,23 @@
 
 import SwiftUI
 
-import Diligence
-import Interact
-
-struct MainWindow: Scene {
-
-    static let id = "main"
+struct RequestsHigherFrequencyUpdates: ViewModifier {
 
     @EnvironmentObject var applicationModel: ApplicationModel
-    @State var error: Error? = nil
 
-    var body: some Scene {
-        WindowGroup(id: Self.id) {
-            ContentView(applicationModel: applicationModel)
-                .handlesAuthentication()
-                .handlesExternalEvents(preferring: [], allowing: [.main])
-        }
-        .defaultSize(CGSize(width: 800, height: 720))
-        .commands {
-            ToolbarCommands()
-        }
-        .handlesExternalEvents(matching: [.main, .auth])
+    func body(content: Content) -> some View {
+        return content
+            .task {
+                await applicationModel.requestHigherFrequencyUpdates()
+            }
+    }
+
+}
+
+extension View {
+
+    func requestsHigherFrequencyUpdates() -> some View {
+        return modifier(RequestsHigherFrequencyUpdates())
     }
 
 }

--- a/Builds/Scenes/SummaryWindow.swift
+++ b/Builds/Scenes/SummaryWindow.swift
@@ -29,10 +29,10 @@ struct SummaryWindow: Scene {
 
     static let id = "summary"
 
-    let applicationModel: ApplicationModel
+    @EnvironmentObject var applicationModel: ApplicationModel
 
     var body: some Scene {
-        Window("Summary", id: Self.id) {
+        WindowGroup("Summary", id: Self.id) {
             SummaryContentView(applicationModel: applicationModel)
         }
         .windowResizability(.contentSize)

--- a/Builds/Views/ContentView.swift
+++ b/Builds/Views/ContentView.swift
@@ -32,12 +32,18 @@ struct ContentView: View {
         case settings
     }
 
+    @ObservedObject var applicationModel: ApplicationModel
+    @StateObject var sceneModel: SceneModel
     @State var sheet: SheetType?
 
     @Environment(\.openURL) var openURL
     @Environment(\.scenePhase) var scenePhase
 
-    @EnvironmentObject var applicationModel: ApplicationModel
+
+    init(applicationModel: ApplicationModel) {
+        self.applicationModel = applicationModel
+        _sceneModel = StateObject(wrappedValue: SceneModel(applicationModel: applicationModel))
+    }
 
     var body: some View {
         NavigationStack {
@@ -90,9 +96,6 @@ struct ContentView: View {
                 }
 
             }
-            .task {
-                await applicationModel.refresh()
-            }
 
         }
         .sheet(item: $sheet) { sheet in
@@ -112,6 +115,9 @@ struct ContentView: View {
                 }
             }
         }
+        .runs(sceneModel)
+        .requestsHigherFrequencyUpdates()
+        .focusedSceneObject(sceneModel)
         .onChange(of: scenePhase) { oldValue, newValue in
             switch newValue {
             case .background:

--- a/Builds/Views/SummaryContentView.swift
+++ b/Builds/Views/SummaryContentView.swift
@@ -47,6 +47,7 @@ struct SummaryContentView: View {
                 openURL(.main)
             }
             .navigationTitle("")
+            .requestsHigherFrequencyUpdates()
     }
 
 }


### PR DESCRIPTION
This change drops the frequency of background updates from 1 minute to 5 minutes when there are no windows. This ensures content is relatively up-to-date when foregrounding the application but means we're not doing too much work in the background.

This also introduces a new scene model in preparation for presenting errors and alerts to the user.