### PR TITLE
fix: Remove the progress spinner

### DIFF
--- a/Builds/Views/ContentView.swift
+++ b/Builds/Views/ContentView.swift
@@ -68,15 +68,6 @@ struct ContentView: View {
             .toolbarTitleDisplayMode(.inline)
             .toolbar {
 
-#if os(macOS)
-                if applicationModel.isUpdating {
-                    ToolbarItem(id: "status", placement: .navigation) {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                }
-#endif
-
 #if os(iOS)
                 ToolbarItem(placement: .topBarLeading) {
                     Button {


### PR DESCRIPTION
This change removes the progress spinner from the macOS app.