### PR TITLE
fix: Use an embedded Safari view controller

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D883F1B92B98019400B00F1C /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D883F1B82B98019400B00F1C /* Sidebar.swift */; };
 		D883F1BB2B9803FD00B00F1C /* SectionIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D883F1BA2B9803FD00B00F1C /* SectionIdentifier.swift */; };
 		D883F1BE2B98087700B00F1C /* WorkflowsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D883F1BD2B98087700B00F1C /* WorkflowsSection.swift */; };
+		D887C5CC2BA0AAF700E46174 /* SafariWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D887C5CB2BA0AAF700E46174 /* SafariWebView.swift */; };
 		D8ADD98F2B9E9E2700D314F1 /* DetailsPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ADD98E2B9E9E2700D314F1 /* DetailsPopover.swift */; };
 		D8ADD9912B9E9E5600D314F1 /* AnnotationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ADD9902B9E9E5600D314F1 /* AnnotationList.swift */; };
 		D8ADD9932B9EA06800D314F1 /* WorkflowJobsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ADD9922B9EA06800D314F1 /* WorkflowJobsList.swift */; };
@@ -99,6 +100,7 @@
 		D883F1B82B98019400B00F1C /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		D883F1BA2B9803FD00B00F1C /* SectionIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIdentifier.swift; sourceTree = "<group>"; };
 		D883F1BD2B98087700B00F1C /* WorkflowsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsSection.swift; sourceTree = "<group>"; };
+		D887C5CB2BA0AAF700E46174 /* SafariWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebView.swift; sourceTree = "<group>"; };
 		D89E58172B65D2AA0027EB4E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D8ADD98E2B9E9E2700D314F1 /* DetailsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsPopover.swift; sourceTree = "<group>"; };
 		D8ADD9902B9E9E5600D314F1 /* AnnotationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationList.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 				D8DA9D882B97009900C17DBC /* WorkflowsPickerModel.swift */,
 				D883F1BD2B98087700B00F1C /* WorkflowsSection.swift */,
 				D8D413EA28044062001BA6C0 /* WorkflowsView.swift */,
+				D887C5CB2BA0AAF700E46174 /* SafariWebView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				D8F0CE0527F89A8100F4EC83 /* GitHubClient.swift in Sources */,
 				D8FEAE0C27F591AE00FDADFA /* BuildsApp.swift in Sources */,
 				D81251BD2B92A39C001F6E85 /* HandlesAuthentication.swift in Sources */,
+				D887C5CC2BA0AAF700E46174 /* SafariWebView.swift in Sources */,
 				D8ADD9912B9E9E5600D314F1 /* AnnotationList.swift in Sources */,
 				D866F250280350BC00FC6EBB /* PhoneSettingsView.swift in Sources */,
 				D81251B42B9181E9001F6E85 /* SummaryContentView.swift in Sources */,

--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -57,22 +57,25 @@
     "Builds" : {
 
     },
+    "Builds uses your GitHub account to retrieve information about your GitHub Actions workflow statuses." : {
+
+    },
     "Cancel" : {
 
     },
     "Done" : {
 
     },
+    "GitHub" : {
+
+    },
     "Loading..." : {
 
     },
-    "Log In" : {
+    "Log In with GitHub" : {
 
     },
-    "Log in to view your GitHub Actions workflows." : {
-
-    },
-    "Log In..." : {
+    "Log In with GitHub..." : {
 
     },
     "Log Out" : {

--- a/Builds/Modifiers/HandlesAuthentication.swift
+++ b/Builds/Modifiers/HandlesAuthentication.swift
@@ -26,7 +26,8 @@ import Interact
 struct HandlesAuthentication: ViewModifier {
 
     @EnvironmentObject var applicationModel: ApplicationModel
-    @State var error: Error? = nil
+    @FocusedObject var sceneModel: SceneModel?
+    @MainActor @State var error: Error? = nil
 
     func body(content: Content) -> some View {
         return content
@@ -41,10 +42,9 @@ struct HandlesAuthentication: ViewModifier {
                 Task {
                     do {
                         try await applicationModel.authenticate(with: url)
+                        sceneModel?.sheet = nil
                     } catch {
-                        DispatchQueue.main.async {
-                            self.error = error
-                        }
+                        self.error = error
                     }
                 }
             }

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -71,8 +71,8 @@ struct MainContentView: View {
                         Label("Manage Workflows", systemImage: "checklist")
                     }
                     .help("Select workflows to display")
+                    .disabled(!applicationModel.isAuthorized)
                 }
-
             }
         }
         .sheet(item: $sceneModel.sheet) { sheet in
@@ -88,8 +88,14 @@ struct MainContentView: View {
                 NavigationView {
 #if os(iOS)
                     PhoneSettingsView()
+                        .environmentObject(sceneModel)
 #endif
                 }
+            case .logIn:
+#if os(iOS)
+                SafariWebView(url: applicationModel.client.authorizationURL)
+                    .ignoresSafeArea()
+#endif
             }
         }
         .runs(sceneModel)

--- a/Builds/Views/PhoneSettingsView.swift
+++ b/Builds/Views/PhoneSettingsView.swift
@@ -27,9 +27,22 @@ import Interact
 
 struct PhoneSettingsView: View {
 
+    enum SheetType: Identifiable {
+
+        var id: Self {
+            return self
+        }
+
+        case managePermissions
+
+    }
+
     @EnvironmentObject var applicationModel: ApplicationModel
+    @EnvironmentObject var sceneModel: SceneModel
 
     @Environment(\.dismiss) var dismiss
+
+    @State var sheet: SheetType? = nil
 
     var body: some View {
         Form {
@@ -41,7 +54,11 @@ struct PhoneSettingsView: View {
             Section {
 
                 Button {
+#if os(macOS)
                     applicationModel.managePermissions()
+#else
+                    sheet = .managePermissions
+#endif
                 } label: {
                     Text("Manage GitHub Permissions")
                 }
@@ -52,7 +69,7 @@ struct PhoneSettingsView: View {
             Section {
 
                 Button {
-                    applicationModel.logOut()
+                    sceneModel.logOut()
                 } label: {
                     Text("Log Out")
                 }
@@ -64,6 +81,13 @@ struct PhoneSettingsView: View {
         .formStyle(.grouped)
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $sheet) { sheet in
+            switch sheet {
+            case .managePermissions:
+                SafariWebView(url: applicationModel.client.permissionsURL)
+                    .ignoresSafeArea()
+            }
+        }
         .dismissable()
     }
 

--- a/Builds/Views/SafariWebView.swift
+++ b/Builds/Views/SafariWebView.swift
@@ -18,38 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(iOS)
+
 import SwiftUI
+import SafariServices
 
-struct AccountCommands: Commands {
+struct SafariWebView: UIViewControllerRepresentable {
+    let url: URL
 
-    @ObservedObject var applicationModel: ApplicationModel
-
-    @FocusedObject var sceneModel: SceneModel?
-
-    var body: some Commands {
-        CommandMenu("Account") {
-            if applicationModel.isAuthorized {
-                Button {
-                    applicationModel.managePermissions()
-                } label: {
-                    Text("Manage GitHub Permissions...")
-                }
-                Divider()
-                Button {
-                    sceneModel?.logOut()
-                } label: {
-                    Text("Log Out...")
-                }
-                .disabled(sceneModel == nil)
-            } else {
-                Button {
-                    sceneModel?.logIn()
-                } label: {
-                    Text("Log In with GitHub...")
-                }
-                .disabled(sceneModel == nil)
-            }
-        }
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        return SFSafariViewController(url: url)
     }
 
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+
+    }
 }
+
+#endif

--- a/Builds/Views/WorkflowsSection.swift
+++ b/Builds/Views/WorkflowsSection.swift
@@ -58,12 +58,12 @@ struct WorkflowsSection: View {
                 ContentUnavailableView {
                     Text("Logged Out")
                 } description: {
-                    Text("Log in to view your GitHub Actions workflows.")
+                    Text("Builds uses your GitHub account to retrieve information about your GitHub Actions workflow statuses.")
                 } actions: {
                     Button {
-                        applicationModel.logIn()
+                        sceneModel.logIn()
                     } label: {
-                        Text("Log In")
+                        Text("Log In with GitHub")
                     }
                 }
             }


### PR DESCRIPTION
App Store Review doesn't like us kicking-out to Mobile Safari on iOS, so this introduces an embedded Safari View Controller for authentication and GitHub permissions management.