### PR TITLE
fix: Fetch results for older workflow runs

### DIFF
--- a/Builds/Model/ApplicationModel.swift
+++ b/Builds/Model/ApplicationModel.swift
@@ -234,6 +234,20 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
             return
         }
         favorites.append(id)
+
+        // Fetch the workflow details on demand.
+        Task {
+            do {
+                try await client.update(favorites: [id]) { [weak self] workflowInstance in
+                    guard let self else {
+                        return
+                    }
+                    self.cachedStatus[workflowInstance.id] = workflowInstance.result
+                }
+            } catch {
+                print("Failed fetch workflow results on demand with error \(error).")
+            }
+        }
     }
 
     @MainActor func removeFavorite(_ id: WorkflowInstance.ID) {

--- a/Builds/Model/ApplicationModel.swift
+++ b/Builds/Model/ApplicationModel.swift
@@ -125,7 +125,12 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
             do {
                 print("Refreshing...")
                 self.isUpdating = true
-                try await self.update(favorites: self.favorites)
+                try await self.client.update(favorites: self.favorites) { [weak self] workflowInstance in
+                    guard let self else {
+                        return
+                    }
+                    self.cachedStatus[workflowInstance.id] = workflowInstance.result
+                }
                 self.lastUpdate = Date()
             } catch {
                 print("Failed to update with error \(error).")
@@ -136,66 +141,6 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
         }
 
         self.start()
-    }
-
-    // TODO: Extract this into an updater.
-
-    // Top level call that triggers fetching all workflow results.
-    private func update(favorites: [WorkflowInstance.ID]) async throws {
-        let repositories = favorites
-            .reduce(into: [String: [WorkflowInstance.ID]]()) { partialResult, id in
-                var ids = partialResult[id.repositoryFullName] ?? []
-                ids.append(id)
-                partialResult[id.id.repositoryFullName] = ids
-            }
-        try await repositories.forEach { repository, ids in
-            try await self.fetchDetails(repository: repository, ids: ids)
-        }
-    }
-
-    // Fetch the workflow details from a single repository.
-    private func fetchDetails(repository: String, ids: [WorkflowInstance.ID]) async throws {
-
-        // Search for workflow runs for each of our requested ids.
-        let ids = Set(ids)
-        let workflowRuns = try await self.client
-            .workflowRuns(for: repository, seekingWorkflowIds: ids)
-            .reduce(into: [WorkflowInstance.ID: GitHub.WorkflowRun]()) { partialResult, workflowRun in
-                let id = WorkflowInstance.ID(repositoryFullName: workflowRun.repository.full_name,
-                                             workflowId: workflowRun.workflow_id,
-                                             branch: workflowRun.head_branch)
-                guard partialResult[id] == nil else {
-                    return
-                }
-                guard ids.contains(id) else {
-                    return
-                }
-                partialResult[id] = workflowRun
-            }
-
-        // Flesh out the build details for each.
-        try await workflowRuns.forEach { id, workflowRun in
-            try await self.fetchDetails(id: id, workflowRun: workflowRun)
-        }
-    }
-
-    // Fetch the details for individual workflows.
-    private func fetchDetails(id: WorkflowInstance.ID, workflowRun: GitHub.WorkflowRun) async throws {
-        let workflowJobs = try await self.client.workflowJobs(for: id.repositoryFullName, workflowRun: workflowRun)
-        var annotations: [WorkflowResult.Annotation] = []
-        for workflowJob in workflowJobs {
-            let results = try await self.client
-                .annotations(for: id.repositoryFullName, workflowJob: workflowJob)
-                .map {
-                    return WorkflowResult.Annotation(jobId: workflowJob.id, annotation: $0)
-                }
-            annotations.append(contentsOf: results)
-        }
-        await MainActor.run {
-            cachedStatus[id] = WorkflowResult(workflowRun: workflowRun,
-                                              jobs: workflowJobs,
-                                              annotations: annotations)
-        }
     }
 
     @MainActor private func start() {

--- a/Builds/Model/ApplicationModel.swift
+++ b/Builds/Model/ApplicationModel.swift
@@ -238,6 +238,7 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
 
     @MainActor func removeFavorite(_ id: WorkflowInstance.ID) {
         favorites.removeAll { $0 == id }
+        cachedStatus.removeValue(forKey: id)
     }
 
     @MainActor func logIn() {

--- a/Builds/Model/GitHub.swift
+++ b/Builds/Model/GitHub.swift
@@ -283,39 +283,6 @@ class GitHub {
         return response.workflow_runs
     }
 
-    // TODO: Remove the 'for'
-    // TODO: I can optionally limit this by branch.
-    // TODO: Move this out.
-    // TODO: Maximimum age / count?
-    func workflowRuns(for repositoryName: String,
-                      authentication: Authentication,
-                      seekingWorkflowIds: any Collection<WorkflowInstance.ID>) async throws -> [WorkflowRun] {
-
-        var workflowIds = Set<WorkflowInstance.ID>()
-        let seekingWorkflowIds = Set(seekingWorkflowIds)
-        var results = [WorkflowRun]()
-        for page in 1..<1000 {
-            let workflowRuns = try await self.workflowRuns(for: repositoryName,
-                                                           page: page,
-                                                           perPage: 100,
-                                                           authentication: authentication)
-            let responseWorkflowIds = await workflowRuns.map { workflowRun in
-                return WorkflowInstance.ID(repositoryFullName: repositoryName,
-                                           workflowId: workflowRun.workflow_id,
-                                           branch: workflowRun.head_branch)
-            }
-            workflowIds.formUnion(responseWorkflowIds)
-            results.append(contentsOf: workflowRuns)
-            if workflowRuns.isEmpty {
-                break
-            }
-            if workflowIds.intersection(seekingWorkflowIds).count == seekingWorkflowIds.count {
-                break
-            }
-        }
-        return results
-    }
-
     // TODO: Paged fetch
     func repositories(authentication: Authentication) async throws -> [Repository] {
         var repositories: [Repository] = []

--- a/Builds/Model/GitHub.swift
+++ b/Builds/Model/GitHub.swift
@@ -254,7 +254,6 @@ class GitHub {
         }
     }
 
-    // TODO: This could be nice to be an async sequence.
     private func fetch<T: Decodable>(_ url: URL,
                                      authentication: Authentication,
                                      page: Int,
@@ -269,7 +268,7 @@ class GitHub {
         return response
     }
 
-    func workflowRuns(for repositoryName: String, page: Int?, perPage: Int?, authentication: Authentication) async throws -> [WorkflowRun] {
+    func workflowRuns(repositoryName: String, page: Int?, perPage: Int?, authentication: Authentication) async throws -> [WorkflowRun] {
         var queryItems: [URLQueryItem] = []
         if let page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
@@ -307,7 +306,6 @@ class GitHub {
     // TODO: Use repositoryname
     func workflows(for repository: Repository, authentication: Authentication) async throws -> [Workflow] {
         let url = URL(string: "https://api.github.com/repos/\(repository.full_name)/actions/workflows")!
-
         let response: Workflows = try await fetch(url, authentication: authentication)
         return response.workflows
     }

--- a/Builds/Model/GitHubClient.swift
+++ b/Builds/Model/GitHubClient.swift
@@ -82,17 +82,14 @@ class GitHubClient {
         return try await api.repositories(authentication: try getAuthentication())
     }
 
-    // TODO: Remove the 'for'
-    // TODO: I can optionally limit this by branch.
-    // TODO: Maximimum age / count?
     func workflowRuns(repositoryName: String,
                       seekingWorkflowIds: any Collection<WorkflowInstance.ID>) async throws -> [GitHub.WorkflowRun] {
 
         var workflowIds = Set<WorkflowInstance.ID>()
         let seekingWorkflowIds = Set(seekingWorkflowIds)
         var results = [GitHub.WorkflowRun]()
-        for page in 1..<1000 {
-            let workflowRuns = try await api.workflowRuns(for: repositoryName,
+        for page in 1..<10 {
+            let workflowRuns = try await api.workflowRuns(repositoryName: repositoryName,
                                                           page: page,
                                                           perPage: 100,
                                                           authentication: try getAuthentication())

--- a/Builds/Model/GitHubClient.swift
+++ b/Builds/Model/GitHubClient.swift
@@ -82,8 +82,10 @@ class GitHubClient {
         return try await api.repositories(authentication: try getAuthentication())
     }
 
-    func workflowRuns(for repositoryName: String) async throws -> [GitHub.WorkflowRun] {
-        return try await api.workflowRuns(for: repositoryName, authentication: try getAuthentication())
+    func workflowRuns(for repositoryName: String, seekingWorkflowIds: any Collection<WorkflowInstance.ID>) async throws -> [GitHub.WorkflowRun] {
+        return try await api.workflowRuns(for: repositoryName,
+                                          authentication: try getAuthentication(),
+                                          seekingWorkflowIds: seekingWorkflowIds)
     }
 
     func branches(for repository: GitHub.Repository) async throws -> [GitHub.Branch] {

--- a/Builds/Model/GitHubClient.swift
+++ b/Builds/Model/GitHubClient.swift
@@ -82,10 +82,100 @@ class GitHubClient {
         return try await api.repositories(authentication: try getAuthentication())
     }
 
-    func workflowRuns(for repositoryName: String, seekingWorkflowIds: any Collection<WorkflowInstance.ID>) async throws -> [GitHub.WorkflowRun] {
-        return try await api.workflowRuns(for: repositoryName,
-                                          authentication: try getAuthentication(),
-                                          seekingWorkflowIds: seekingWorkflowIds)
+    // TODO: Remove the 'for'
+    // TODO: I can optionally limit this by branch.
+    // TODO: Maximimum age / count?
+    func workflowRuns(repositoryName: String,
+                      seekingWorkflowIds: any Collection<WorkflowInstance.ID>) async throws -> [GitHub.WorkflowRun] {
+
+        var workflowIds = Set<WorkflowInstance.ID>()
+        let seekingWorkflowIds = Set(seekingWorkflowIds)
+        var results = [GitHub.WorkflowRun]()
+        for page in 1..<1000 {
+            let workflowRuns = try await api.workflowRuns(for: repositoryName,
+                                                          page: page,
+                                                          perPage: 100,
+                                                          authentication: try getAuthentication())
+            let responseWorkflowIds = await workflowRuns.map { workflowRun in
+                return WorkflowInstance.ID(repositoryFullName: repositoryName,
+                                           workflowId: workflowRun.workflow_id,
+                                           branch: workflowRun.head_branch)
+            }
+            workflowIds.formUnion(responseWorkflowIds)
+            results.append(contentsOf: workflowRuns)
+            if workflowRuns.isEmpty {
+                break
+            }
+            if workflowIds.intersection(seekingWorkflowIds).count == seekingWorkflowIds.count {
+                break
+            }
+        }
+        return results
+    }
+
+    // Top level call that triggers fetching all workflow results.
+    func update(favorites: [WorkflowInstance.ID],
+                        callback: @escaping (WorkflowInstance) -> Void) async throws {
+        let repositories = favorites
+            .reduce(into: [String: [WorkflowInstance.ID]]()) { partialResult, id in
+                var ids = partialResult[id.repositoryFullName] ?? []
+                ids.append(id)
+                partialResult[id.id.repositoryFullName] = ids
+            }
+        try await repositories.forEach { repository, ids in
+            try await self.fetchDetails(repository: repository, ids: ids, callback: callback)
+        }
+    }
+
+    // Fetch the workflow details from a single repository.
+    private func fetchDetails(repository: String,
+                              ids: [WorkflowInstance.ID],
+                              callback: @escaping (WorkflowInstance) -> Void) async throws {
+
+        // Search for workflow runs for each of our requested ids.
+        let ids = Set(ids)
+        let workflowRuns = try await self
+            .workflowRuns(repositoryName: repository, seekingWorkflowIds: ids)
+            .reduce(into: [WorkflowInstance.ID: GitHub.WorkflowRun]()) { partialResult, workflowRun in
+                let id = WorkflowInstance.ID(repositoryFullName: workflowRun.repository.full_name,
+                                             workflowId: workflowRun.workflow_id,
+                                             branch: workflowRun.head_branch)
+                guard partialResult[id] == nil else {
+                    return
+                }
+                guard ids.contains(id) else {
+                    return
+                }
+                partialResult[id] = workflowRun
+            }
+
+        // Flesh out the build details for each.
+        try await workflowRuns.forEach { id, workflowRun in
+            try await self.fetchDetails(id: id, workflowRun: workflowRun, callback: callback)
+        }
+    }
+
+    // Fetch the details for individual workflows.
+    private func fetchDetails(id: WorkflowInstance.ID,
+                              workflowRun: GitHub.WorkflowRun,
+                              callback: @escaping (WorkflowInstance) -> Void) async throws {
+        let workflowJobs = try await self.workflowJobs(for: id.repositoryFullName, workflowRun: workflowRun)
+        var annotations: [WorkflowResult.Annotation] = []
+        for workflowJob in workflowJobs {
+            let results = try await self
+                .annotations(for: id.repositoryFullName, workflowJob: workflowJob)
+                .map {
+                    return WorkflowResult.Annotation(jobId: workflowJob.id, annotation: $0)
+                }
+            annotations.append(contentsOf: results)
+        }
+        let workflowInstance = WorkflowInstance(id: id,
+                                                result: WorkflowResult(workflowRun: workflowRun,
+                                                                       jobs: workflowJobs,
+                                                                       annotations: annotations))
+        await MainActor.run {
+            callback(workflowInstance)
+        }
     }
 
     func branches(for repository: GitHub.Repository) async throws -> [GitHub.Branch] {


### PR DESCRIPTION
This change also updates results as soon as they come in and fixes result caching.