### PR TITLE
fix: Fix a crash when opening new windows on iPad

### DIFF
--- a/Builds/Scenes/MainWindow.swift
+++ b/Builds/Scenes/MainWindow.swift
@@ -35,6 +35,7 @@ struct MainWindow: Scene {
             MainContentView(applicationModel: applicationModel)
                 .handlesAuthentication()
                 .handlesExternalEvents(preferring: [], allowing: [.main])
+                .environmentObject(applicationModel)
         }
         .defaultSize(CGSize(width: 800, height: 720))
         .commands {


### PR DESCRIPTION
This belt-and-braces change seems to fix an issue on the iPad when the `ApplicationModel` environment object isn't available when launching new windows (even though it's injected at the scene level).