### PR TITLE
fix: Check for HTTP error codes

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		D8355DCF27F63B680091BAFD /* GitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8355DCE27F63B680091BAFD /* GitHub.swift */; };
 		D8355DD227F674F20091BAFD /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8355DD127F674F20091BAFD /* URL.swift */; };
 		D83929DB2BA367DD0022B4A3 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83929DA2BA367DD0022B4A3 /* Collection.swift */; };
+		D83DE3962BB218CB00234B01 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83DE3952BB218CB00234B01 /* HTTPStatusCode.swift */; };
 		D850F4D72BAA4E7B00CE1796 /* Confirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850F4D62BAA4E7B00CE1796 /* Confirmation.swift */; };
 		D850F4D92BAA4EA700CE1796 /* PresentsConfirmable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850F4D82BAA4EA700CE1796 /* PresentsConfirmable.swift */; };
 		D850F4DB2BAA709800CE1796 /* Confirmable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850F4DA2BAA709800CE1796 /* Confirmable.swift */; };
@@ -28,6 +29,7 @@
 		D87390F02BA134D400EFC8B8 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */; };
 		D87F23742B6600150085DC12 /* material-icons-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23732B6600150085DC12 /* material-icons-license */; };
 		D87F23762B66006F0085DC12 /* builds-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23752B66006F0085DC12 /* builds-license */; };
+		D88208DB2BB23C030075E9B7 /* HTTPURLResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88208DA2BB23C030075E9B7 /* HTTPURLResponseError.swift */; };
 		D883F1B52B97EC9E00B00F1C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D883F1B42B97EC9E00B00F1C /* Localizable.xcstrings */; };
 		D883F1B72B97FD6F00B00F1C /* Dismissable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D883F1B62B97FD6F00B00F1C /* Dismissable.swift */; };
 		D883F1B92B98019400B00F1C /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D883F1B82B98019400B00F1C /* Sidebar.swift */; };
@@ -109,6 +111,7 @@
 		D8355DCE27F63B680091BAFD /* GitHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHub.swift; sourceTree = "<group>"; };
 		D8355DD127F674F20091BAFD /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		D83929DA2BA367DD0022B4A3 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		D83DE3952BB218CB00234B01 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		D850F4D62BAA4E7B00CE1796 /* Confirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Confirmation.swift; sourceTree = "<group>"; };
 		D850F4D82BAA4EA700CE1796 /* PresentsConfirmable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentsConfirmable.swift; sourceTree = "<group>"; };
 		D850F4DA2BAA709800CE1796 /* Confirmable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Confirmable.swift; sourceTree = "<group>"; };
@@ -121,6 +124,7 @@
 		D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
 		D87F23732B6600150085DC12 /* material-icons-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "material-icons-license"; sourceTree = "<group>"; };
 		D87F23752B66006F0085DC12 /* builds-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "builds-license"; sourceTree = "<group>"; };
+		D88208DA2BB23C030075E9B7 /* HTTPURLResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPURLResponseError.swift; sourceTree = "<group>"; };
 		D883F1B42B97EC9E00B00F1C /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		D883F1B62B97FD6F00B00F1C /* Dismissable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dismissable.swift; sourceTree = "<group>"; };
 		D883F1B82B98019400B00F1C /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
@@ -308,6 +312,8 @@
 				D850F4D62BAA4E7B00CE1796 /* Confirmation.swift */,
 				D8355DCE27F63B680091BAFD /* GitHub.swift */,
 				D8F0CE0427F89A8100F4EC83 /* GitHubClient.swift */,
+				D83DE3952BB218CB00234B01 /* HTTPStatusCode.swift */,
+				D88208DA2BB23C030075E9B7 /* HTTPURLResponseError.swift */,
 				D8EE7DD02B7F341800A3DCF0 /* Legal.swift */,
 				D8CA0EEF2B940BBB00DAE758 /* RefreshScheduler.swift */,
 				D8DA9D8A2B97011800C17DBC /* RepositoryDetails.swift */,
@@ -591,6 +597,7 @@
 				D8D413F528045577001BA6C0 /* WorkflowResult.swift in Sources */,
 				D81251B62B918472001F6E85 /* SummaryState.swift in Sources */,
 				D8EE7DD32B7F3A2900A3DCF0 /* AboutButton.swift in Sources */,
+				D83DE3962BB218CB00234B01 /* HTTPStatusCode.swift in Sources */,
 				D8FEAE0E27F591AE00FDADFA /* MainContentView.swift in Sources */,
 				D8D413F9280479B7001BA6C0 /* Configuration.swift in Sources */,
 				D8EE7DD12B7F341800A3DCF0 /* Legal.swift in Sources */,
@@ -611,6 +618,7 @@
 				D8D413FD28047B85001BA6C0 /* Bundle.swift in Sources */,
 				D887C5D82BA0B49600E46174 /* SVGImage.swift in Sources */,
 				D8DA9D812B96FFEC00C17DBC /* WorkflowsContentView.swift in Sources */,
+				D88208DB2BB23C030075E9B7 /* HTTPURLResponseError.swift in Sources */,
 				D8CA0EF42B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift in Sources */,
 				D83929DB2BA367DD0022B4A3 /* Collection.swift in Sources */,
 				D8DA9D892B97009900C17DBC /* WorkflowsPickerModel.swift in Sources */,

--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -117,6 +117,9 @@
     "Manage Workflows" : {
 
     },
+    "Never Updated" : {
+
+    },
     "No Workflow Selected" : {
 
     },
@@ -212,6 +215,9 @@
 
     },
     "Updated" : {
+
+    },
+    "Updating..." : {
 
     },
     "Workflow" : {

--- a/Builds/Model/ApplicationModel.swift
+++ b/Builds/Model/ApplicationModel.swift
@@ -85,11 +85,9 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
         }
     }
 
-    @MainActor @Published private var activeScenes = 0 {
-        didSet {
-            print("activeScenes = \(activeScenes)")
-        }
-    }
+    @MainActor @Published var lastError: Error? = nil
+
+    @MainActor @Published private var activeScenes = 0
 
     // TODO: Make this private.
     // TODO: This should be optional; there's no point it existing if we don't have an auth code.
@@ -125,6 +123,7 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
             do {
                 print("Refreshing...")
                 self.isUpdating = true
+                self.lastError = nil
                 try await self.client.update(favorites: self.favorites) { [weak self] workflowInstance in
                     guard let self else {
                         return
@@ -133,6 +132,7 @@ class ApplicationModel: NSObject, ObservableObject, AuthenticationProvider {
                 }
                 self.lastUpdate = Date()
             } catch {
+                self.lastError = error
                 print("Failed to update with error \(error).")
             }
             self.isUpdating = false

--- a/Builds/Model/GitHub.swift
+++ b/Builds/Model/GitHub.swift
@@ -243,7 +243,8 @@ class GitHub {
         var request = URLRequest(url: url)
         request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
         request.setValue("token \(authentication.accessToken)", forHTTPHeaderField: "Authorization")
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try response.checkHTTPStatusCode()
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         do {
@@ -268,7 +269,10 @@ class GitHub {
         return response
     }
 
-    func workflowRuns(repositoryName: String, page: Int?, perPage: Int?, authentication: Authentication) async throws -> [WorkflowRun] {
+    func workflowRuns(repositoryName: String,
+                      page: Int?,
+                      perPage: Int?,
+                      authentication: Authentication) async throws -> [WorkflowRun] {
         var queryItems: [URLQueryItem] = []
         if let page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
@@ -342,7 +346,8 @@ class GitHub {
             }
             var request = URLRequest(url: url)
             request.setValue("application/json", forHTTPHeaderField: "Accept")
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try response.checkHTTPStatusCode()
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             let accessToken = try decoder.decode(AccessToken.self, from: data)
@@ -376,9 +381,8 @@ class GitHub {
             "access_token": authentication.accessToken,
         ])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
-        print(response)
-        print(String(data: data, encoding: .utf8) ?? "nil")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        try response.checkHTTPStatusCode()
     }
 
     private func url(_ path: Path, parameters: [String: String] = [:]) -> URL? {

--- a/Builds/Model/HTTPStatusCode.swift
+++ b/Builds/Model/HTTPStatusCode.swift
@@ -1,0 +1,395 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+// https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+
+struct HTTPStatusCode: CaseIterable, Equatable, Hashable {
+
+    static func ==(lhs: HTTPStatusCode, rhs: Int) -> Bool {
+         return lhs.rawValue == rhs
+     }
+
+     static func ==(lhs: Int, rhs: HTTPStatusCode) -> Bool {
+         return lhs == rhs.rawValue
+     }
+
+    // 1XX Informational Response
+    static let `continue` = HTTPStatusCode(rawValue: 100)
+    static let switchingProtocols = HTTPStatusCode(rawValue: 101)
+    static let processing = HTTPStatusCode(rawValue: 102)
+    static let earlyHints = HTTPStatusCode(rawValue: 103)
+
+    // 2XX Success
+    static let ok = HTTPStatusCode(rawValue: 200)
+    static let created = HTTPStatusCode(rawValue: 201)
+    static let accepted = HTTPStatusCode(rawValue: 202)
+    static let nonAuthoritativeInformation = HTTPStatusCode(rawValue: 203)
+    static let noContent = HTTPStatusCode(rawValue: 204)
+    static let resetContent = HTTPStatusCode(rawValue: 205)
+    static let partialContent = HTTPStatusCode(rawValue: 206)
+    static let multiStatus = HTTPStatusCode(rawValue: 207)
+    static let alreadyReported = HTTPStatusCode(rawValue: 208)
+    static let imUsed = HTTPStatusCode(rawValue: 226)
+
+    // 3XX Redirection
+    static let multipleChoices = HTTPStatusCode(rawValue: 300)
+    static let movedPermanently = HTTPStatusCode(rawValue: 301)
+    static let found = HTTPStatusCode(rawValue: 302)
+    static let seeOther = HTTPStatusCode(rawValue: 303)
+    static let notModified = HTTPStatusCode(rawValue: 304)
+    static let useProxy = HTTPStatusCode(rawValue: 305)
+    static let switchProxy = HTTPStatusCode(rawValue: 306)
+    static let temporaryRedirect = HTTPStatusCode(rawValue: 307)
+    static let permanentRedirect = HTTPStatusCode(rawValue: 308)
+
+    // 4XX Client Errors
+    static let badRequest = HTTPStatusCode(rawValue: 400)
+    static let unauthorized = HTTPStatusCode(rawValue: 401)
+    static let paymentRequired = HTTPStatusCode(rawValue: 402)
+    static let forbidden = HTTPStatusCode(rawValue: 403)
+    static let notFound = HTTPStatusCode(rawValue: 404)
+    static let methodNotAllowed = HTTPStatusCode(rawValue: 405)
+    static let notAcceptable = HTTPStatusCode(rawValue: 406)
+    static let proxyAuthenticationRequired = HTTPStatusCode(rawValue: 407)
+    static let requestTimeout = HTTPStatusCode(rawValue: 408)
+    static let conflict = HTTPStatusCode(rawValue: 409)
+    static let gone = HTTPStatusCode(rawValue: 410)
+    static let lengthRequired = HTTPStatusCode(rawValue: 411)
+    static let preconditionFailed = HTTPStatusCode(rawValue: 412)
+    static let payloadTooLarge = HTTPStatusCode(rawValue: 413)
+    static let uriTooLong = HTTPStatusCode(rawValue: 414)
+    static let unsupportedMediaType = HTTPStatusCode(rawValue: 415)
+    static let rangeNotSatisfiable = HTTPStatusCode(rawValue: 416)
+    static let expectationFailed = HTTPStatusCode(rawValue: 417)
+    static let imATeapot = HTTPStatusCode(rawValue: 418)
+    static let misdirectedRequest = HTTPStatusCode(rawValue: 421)
+    static let unprocessableContent = HTTPStatusCode(rawValue: 422)
+    static let locked = HTTPStatusCode(rawValue: 423)
+    static let failedDependency = HTTPStatusCode(rawValue: 424)
+    static let tooEarly = HTTPStatusCode(rawValue: 425)
+    static let upgradeRequired = HTTPStatusCode(rawValue: 426)
+    static let preconditionRequired = HTTPStatusCode(rawValue: 428)
+    static let tooManyRequests = HTTPStatusCode(rawValue: 429)
+    static let requestHeaderFieldsTooLarge = HTTPStatusCode(rawValue: 431)
+    static let unavailableForLegalReasons = HTTPStatusCode(rawValue: 451)
+
+    // 5XX Server Errors
+    static let internalServerError = HTTPStatusCode(rawValue: 500)
+    static let notImplemented = HTTPStatusCode(rawValue: 501)
+    static let badGateway = HTTPStatusCode(rawValue: 502)
+    static let serviceUnavailable = HTTPStatusCode(rawValue: 503)
+    static let gatewayTimeout = HTTPStatusCode(rawValue: 504)
+    static let httpVersionNotSupported = HTTPStatusCode(rawValue: 505)
+    static let variantAlsoNegotiates = HTTPStatusCode(rawValue: 506)
+    static let insufficientStorage = HTTPStatusCode(rawValue: 507)
+    static let loopDetected = HTTPStatusCode(rawValue: 508)
+    static let startingTicketRequired = HTTPStatusCode(rawValue: 509)
+    static let notExtended = HTTPStatusCode(rawValue: 510)
+    static let networkAuthenticationRequired = HTTPStatusCode(rawValue: 511)
+
+    // 6XX Multi-Sided Errors
+    static let inaccessibleRequest = HTTPStatusCode(rawValue: 604)
+    static let notAllowed = HTTPStatusCode(rawValue: 605)
+    static let requestDeletedOrModified = HTTPStatusCode(rawValue: 644)
+
+    static var allCases: [HTTPStatusCode] = [
+
+        // 1XX Informational Response
+        `continue`,
+        switchingProtocols,
+        processing,
+        earlyHints,
+
+        // 2XX Success
+        ok,
+        created,
+        accepted,
+        nonAuthoritativeInformation,
+        noContent,
+        resetContent,
+        partialContent,
+        multiStatus,
+        alreadyReported,
+        imUsed,
+
+        // 3XX Redirection
+        multipleChoices,
+        movedPermanently,
+        found,
+        seeOther,
+        notModified,
+        useProxy,
+        switchProxy,
+        temporaryRedirect,
+        permanentRedirect,
+
+        // 4XX Client Errors
+        badRequest,
+        unauthorized,
+        paymentRequired,
+        forbidden,
+        notFound,
+        methodNotAllowed,
+        notAcceptable,
+        proxyAuthenticationRequired,
+        requestTimeout,
+        conflict,
+        gone,
+        lengthRequired,
+        preconditionFailed,
+        payloadTooLarge,
+        uriTooLong,
+        unsupportedMediaType,
+        rangeNotSatisfiable,
+        expectationFailed,
+        imATeapot,
+        misdirectedRequest,
+        unprocessableContent,
+        locked,
+        failedDependency,
+        tooEarly,
+        upgradeRequired,
+        preconditionRequired,
+        tooManyRequests,
+        requestHeaderFieldsTooLarge,
+        unavailableForLegalReasons,
+
+        // 5XX Server Errors
+        internalServerError,
+        notImplemented,
+        badGateway,
+        serviceUnavailable,
+        gatewayTimeout,
+        httpVersionNotSupported,
+        variantAlsoNegotiates,
+        insufficientStorage,
+        loopDetected,
+        startingTicketRequired,
+        notExtended,
+        networkAuthenticationRequired,
+
+        // 6XX Multi-Sided Codes
+        inaccessibleRequest,
+        notAllowed,
+        requestDeletedOrModified,
+    ]
+
+    var isSuccess: Bool {
+        return Set<HTTPStatusCode>.allSuccesses.contains(self)
+    }
+
+    let rawValue: Int
+
+}
+
+extension HTTPStatusCode {
+
+    var localizedDescription: String {
+        switch self {
+
+        // 1XX Informational Response
+        case .continue:
+            return "Continue"
+        case .switchingProtocols:
+            return "Switching Protocols"
+        case .processing:
+            return "Processing"
+        case .earlyHints:
+            return "Early Hints"
+
+        // 2XX Success
+        case .ok:
+            return "OK"
+        case .created:
+            return "Created"
+        case .accepted:
+            return "Accepted"
+        case .nonAuthoritativeInformation:
+            return "Non-Authorative Information"
+        case .noContent:
+            return "No Content"
+        case .resetContent:
+            return "Reset Content"
+        case .partialContent:
+            return "Partial Content"
+        case .multiStatus:
+            return "Multi-Status"
+        case .alreadyReported:
+            return "Already Reported"
+        case .imUsed:
+            return "IM Used"
+
+        // 3XX Redirection
+        case .multipleChoices:
+            return "Multiple Choices"
+        case .movedPermanently:
+            return "Moved Permanently"
+        case .found:
+            return "Found"
+        case .seeOther:
+            return "See Other"
+        case .notModified:
+            return "Not Modified"
+        case .useProxy:
+            return "Use Proxy"
+        case .switchProxy:
+            return "Switch Proxy"
+        case .temporaryRedirect:
+            return "Temporary Redirect"
+        case .permanentRedirect:
+            return "Permanent Redirect"
+
+        // 4XX Client Errors
+        case .badRequest:
+            return "Bad Request"
+        case .unauthorized:
+            return "Unauthorized"
+        case .paymentRequired:
+            return "Payment Required"
+        case .forbidden:
+            return "Forbidden"
+        case .notFound:
+            return "Not Found"
+        case .methodNotAllowed:
+            return "Method Not Allowed"
+        case .notAcceptable:
+            return "Not Acceptable"
+        case .proxyAuthenticationRequired:
+            return "Proxy Authentication Required"
+        case .requestTimeout:
+            return "Request Timeout"
+        case .conflict:
+            return "Conflict"
+        case .gone:
+            return "Gone"
+        case .lengthRequired:
+            return "Length Required"
+        case .preconditionFailed:
+            return "Precondition Failed"
+        case .payloadTooLarge:
+            return "Payload Too Large"
+        case .uriTooLong:
+            return "URI Too Long"
+        case .unsupportedMediaType:
+            return "Unsupported Media Type"
+        case .rangeNotSatisfiable:
+            return "Range Not Satisfiable"
+        case .expectationFailed:
+            return "Expectation Failed"
+        case .imATeapot:
+            return "I'm a Teapot"
+        case .misdirectedRequest:
+            return "Misdirected Request"
+        case .unprocessableContent:
+            return "Unprocessable Content"
+        case .locked:
+            return "Locked"
+        case .failedDependency:
+            return "Failed Dependency"
+        case .tooEarly:
+            return "Too Early"
+        case .upgradeRequired:
+            return "Upgrade Required"
+        case .preconditionRequired:
+            return "Precondition Required"
+        case .tooManyRequests:
+            return "Too Many Requests"
+        case .requestHeaderFieldsTooLarge:
+            return "Request Header Fields Too Large"
+        case .unavailableForLegalReasons:
+            return "Unavailable For Legal Reasons"
+
+        // 5XX Server Errors
+        case .internalServerError:
+            return "Internal Server Error"
+        case .notImplemented:
+            return "Not Implemented"
+        case .badGateway:
+            return "Bad Gateway"
+        case .serviceUnavailable:
+            return "Service Unavailable"
+        case .gatewayTimeout:
+            return "Gateway Timeout"
+        case .httpVersionNotSupported:
+            return "HTTP Version Not Supported"
+        case .variantAlsoNegotiates:
+            return "Variant Also Negotiates"
+        case .insufficientStorage:
+            return "Insufficient Storage"
+        case .loopDetected:
+            return "Loop Detected"
+        case .startingTicketRequired:
+            return "Starting Ticket Required"
+        case .notExtended:
+            return "Not Extended"
+        case .networkAuthenticationRequired:
+            return "Network Authentication Required"
+
+        // 6XX Multi-Sided Codes
+        case .inaccessibleRequest:
+            return "Inaccessible Request"
+        case .notAllowed:
+            return "Not Allowed"
+        case .requestDeletedOrModified:
+            return "Request Deleted Or Modified"
+
+        default:
+            return "Unknown HTTP response code (\(rawValue))"
+        }
+    }
+
+}
+
+extension Set where Element == HTTPStatusCode {
+
+    static var allInformationalResponses: Self = .init(100..<200)
+    static var allSuccesses: Self = .init(200..<300)
+    static var allRedirections: Self = .init(300..<400)
+    static var allClientErrors: Self = .init(400..<500)
+    static var allServerErrors: Self = .init(500..<600)
+    static var allMultiSidedErrors: Self = .init(600..<700)
+
+    private init(_ range: Range<Int>) {
+        self = Set(range.map({ HTTPStatusCode(rawValue: $0) }))
+    }
+
+    static func |(lhs: Self, rhs: Self) -> Self {
+        return lhs.union(rhs)
+    }
+
+    static func |(lhs: Self, rhs: HTTPStatusCode) -> Self {
+        return lhs.union([rhs])
+    }
+
+    static func |(lhs: HTTPStatusCode, rhs: Self) -> Self {
+        return rhs.union([lhs])
+    }
+
+}
+
+extension HTTPStatusCode {
+
+    static func |(lhs: Self, rhs: Self) -> Set<HTTPStatusCode> {
+        return Set([lhs, rhs])
+    }
+
+}

--- a/Builds/Model/HTTPURLResponseError.swift
+++ b/Builds/Model/HTTPURLResponseError.swift
@@ -1,0 +1,61 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+enum HTTPURLResponseError: Error {
+
+    case invalidResponse
+    case httpError(HTTPStatusCode)
+
+}
+
+extension HTTPURLResponseError: LocalizedError {
+
+    var errorDescription: String? {
+
+        switch self {
+        case .invalidResponse:
+            return "Response isn't HTTP"
+        case .httpError(let statusCode):
+            return statusCode.localizedDescription
+        }
+
+    }
+
+}
+
+extension URLResponse {
+
+    func checkHTTPStatusCode(permitting statusCode: HTTPStatusCode) throws {
+        return try self.checkHTTPStatusCode(permitting: [statusCode])
+    }
+
+    func checkHTTPStatusCode(permitting: Set<HTTPStatusCode> = .allSuccesses) throws {
+        guard let httpResponse = self as? HTTPURLResponse else {
+            throw HTTPURLResponseError.invalidResponse
+        }
+        let statusCode = HTTPStatusCode(rawValue: httpResponse.statusCode)
+        guard permitting.contains(statusCode) else {
+            throw HTTPURLResponseError.httpError(statusCode)
+        }
+    }
+
+}

--- a/Builds/Views/WorkflowsSection.swift
+++ b/Builds/Views/WorkflowsSection.swift
@@ -73,6 +73,28 @@ struct WorkflowsSection: View {
                             .presentationDetents([.large])
                             .presentationBackgroundInteraction(.enabled(upThrough: .height(200)))
                         }
+#if os(macOS)
+                        .safeAreaInset(edge: .bottom) {
+                            VStack(spacing: 0) {
+                                Divider()
+                                HStack {
+                                    if applicationModel.isUpdating {
+                                        Text("Updating...")
+                                    } else if let lastError = applicationModel.lastError {
+                                        Label(lastError.localizedDescription, systemImage: "exclamationmark.triangle")
+                                            .symbolRenderingMode(.multicolor)
+                                    } else if let lastUpdate = applicationModel.lastUpdate {
+                                        Text(lastUpdate, style: .time)
+                                    } else {
+                                        Text("Never Updated")
+                                    }
+                                }
+                                .padding()
+                            }
+                            .foregroundStyle(.secondary)
+                            .background(.thinMaterial)
+                        }
+#endif
                 } else {
                     ContentUnavailableView {
                         Label("No Workflows", systemImage: "checklist.unchecked")


### PR DESCRIPTION
This change adds explicit checking for HTTP error codes when interacting with the GitHub API. It also tracks the last sync error in `ApplicationModel` and adds placeholder UI on macOS to surface this during testing. Issues #79 (https://github.com/inseven/builds/issues/79) and #207 (https://github.com/inseven/builds/issues/207) are tracking the work to improve the UX around update errors.