### PR TITLE
fix: Show commit details in the inspector

### DIFF
--- a/Builds/Extensions/URL.swift
+++ b/Builds/Extensions/URL.swift
@@ -33,7 +33,15 @@ public extension URL {
     }
 
     init?(repositoryFullName: String) {
-        self = Self.gitHub.appendingPathComponent(repositoryFullName)
+        self = Self.gitHub
+            .appendingPathComponent(repositoryFullName)
+    }
+
+    init?(repositoryFullName: String, commit: String) {
+        self = Self.gitHub
+            .appendingPathComponent(repositoryFullName)
+            .appendingPathComponent("commit")
+            .appendingPathComponent(commit)
     }
 
     func settingQueryItems(_ queryItems: [URLQueryItem]) -> URL? {

--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -78,6 +78,9 @@
     "Cancel" : {
 
     },
+    "Commit" : {
+
+    },
     "Confirm" : {
 
     },
@@ -130,6 +133,9 @@
 
     },
     "Open" : {
+
+    },
+    "Open Commit" : {
 
     },
     "Open Repository" : {

--- a/Builds/Model/WorkflowInstance.swift
+++ b/Builds/Model/WorkflowInstance.swift
@@ -52,6 +52,13 @@ struct WorkflowInstance: Identifiable, Hashable {
         return result?.annotations ?? []
     }
 
+    var commitURL: URL? {
+        guard let result else {
+            return nil
+        }
+        return URL(repositoryFullName: id.repositoryFullName, commit: result.workflowRun.head_sha)
+    }
+
     var details: String {
         return "\(workflowName) (\(id.branch))"
     }

--- a/Builds/Views/WorkflowInspector.swift
+++ b/Builds/Views/WorkflowInspector.swift
@@ -63,6 +63,22 @@ struct WorkflowInspector: View {
                 } label: {
                     Text("Branch")
                 }
+                if let result = workflowInstance.result {
+                    Button {
+                        guard let url = workflowInstance.commitURL else {
+                            return
+                        }
+                        openURL(url)
+                    } label: {
+                        LabeledContent {
+                            Text(result.workflowRun.head_sha.prefix(7))
+                                .foregroundStyle(.link)
+                                .monospaced()
+                        } label: {
+                            Text("Commit")
+                        }
+                    }
+                }
             }
             if let result = workflowInstance.result {
                 Section {

--- a/Builds/Views/WorkflowsView.swift
+++ b/Builds/Views/WorkflowsView.swift
@@ -62,6 +62,15 @@ struct WorkflowsView: View {
             }
             .disabled(results.isEmpty)
 
+            Divider()
+
+            MenuItem("Open Commit", systemImage: "safari") {
+                for url in workflowInstances.compactMap({ $0.commitURL }) {
+                    openURL(url)
+                }
+            }
+            .disabled(results.isEmpty)
+
             MenuItem("Open Repository", systemImage: "safari") {
                 for url in workflowInstances.compactMap({ $0.repositoryURL }) {
                     openURL(url)


### PR DESCRIPTION
This change also adds support for opening the commit in the system browser from both the context menu and the inspector.