### PR TITLE
fix: Disable multiple scenes on iPadOS

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -806,7 +806,6 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Builds/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -846,7 +845,6 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Builds/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Builds/Info.plist
+++ b/Builds/Info.plist
@@ -27,6 +27,13 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>


### PR DESCRIPTION
This change disables multiple scenes on iPadOS to address issues where multiple scenes were being created when opening the app from the App Library (check out https://github.com/jbmorley/swiftui-multi-window-issues/ for a more involved discussion on the issues seen). Ultimately this is a simplifying decision--the app doesn't feel like it gains a lot from having multiple windows and they seem precarious enough in SwiftUI that it's just not worth the development time and resulting inconsistent user experience. We can revisit this in the future if the APIs improve and users really want this functionality.