### PR TITLE
fix: Unable to sign out on iPad

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		D87390F02BA134D400EFC8B8 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */; };
 		D87F23742B6600150085DC12 /* material-icons-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23732B6600150085DC12 /* material-icons-license */; };
 		D87F23762B66006F0085DC12 /* builds-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23752B66006F0085DC12 /* builds-license */; };
+		D8800B632BB4B25800AD3BB7 /* SheetReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8800B622BB4B25800AD3BB7 /* SheetReader.swift */; };
 		D88208DB2BB23C030075E9B7 /* HTTPURLResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88208DA2BB23C030075E9B7 /* HTTPURLResponseError.swift */; };
 		D883F1B52B97EC9E00B00F1C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D883F1B42B97EC9E00B00F1C /* Localizable.xcstrings */; };
 		D883F1B72B97FD6F00B00F1C /* Dismissable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D883F1B62B97FD6F00B00F1C /* Dismissable.swift */; };
@@ -124,6 +125,7 @@
 		D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
 		D87F23732B6600150085DC12 /* material-icons-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "material-icons-license"; sourceTree = "<group>"; };
 		D87F23752B66006F0085DC12 /* builds-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "builds-license"; sourceTree = "<group>"; };
+		D8800B622BB4B25800AD3BB7 /* SheetReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetReader.swift; sourceTree = "<group>"; };
 		D88208DA2BB23C030075E9B7 /* HTTPURLResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPURLResponseError.swift; sourceTree = "<group>"; };
 		D883F1B42B97EC9E00B00F1C /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		D883F1B62B97FD6F00B00F1C /* Dismissable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dismissable.swift; sourceTree = "<group>"; };
@@ -337,10 +339,12 @@
 				D8FEAE0D27F591AE00FDADFA /* MainContentView.swift */,
 				D866F24F280350BC00FC6EBB /* PhoneSettingsView.swift */,
 				D86B1D2F2B9EA78000CA4E21 /* PopoverButton.swift */,
+				D8A269B02BAA3B6800A0E19A /* ProgressSpinner.swift */,
 				D887C5CB2BA0AAF700E46174 /* SafariWebView.swift */,
+				D8800B622BB4B25800AD3BB7 /* SheetReader.swift */,
 				D883F1B82B98019400B00F1C /* Sidebar.swift */,
-				D86A91462B9E5FF30008FF63 /* WorkflowInspector.swift */,
 				D887C5D72BA0B49600E46174 /* SVGImage.swift */,
+				D86A91462B9E5FF30008FF63 /* WorkflowInspector.swift */,
 				D8D413E828043FCD001BA6C0 /* WorkflowInstanceCell.swift */,
 				D8ADD9922B9EA06800D314F1 /* WorkflowJobsList.swift */,
 				D8DA9D802B96FFEC00C17DBC /* WorkflowsContentView.swift */,
@@ -348,7 +352,6 @@
 				D8DA9D882B97009900C17DBC /* WorkflowsPickerModel.swift */,
 				D883F1BD2B98087700B00F1C /* WorkflowsSection.swift */,
 				D8D413EA28044062001BA6C0 /* WorkflowsView.swift */,
-				D8A269B02BAA3B6800A0E19A /* ProgressSpinner.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 				D883F1BE2B98087700B00F1C /* WorkflowsSection.swift in Sources */,
 				D8DA9D852B97004900C17DBC /* WorkflowsWindow.swift in Sources */,
 				D8F0CE0527F89A8100F4EC83 /* GitHubClient.swift in Sources */,
+				D8800B632BB4B25800AD3BB7 /* SheetReader.swift in Sources */,
 				D8FEAE0C27F591AE00FDADFA /* BuildsApp.swift in Sources */,
 				D81251BD2B92A39C001F6E85 /* HandlesAuthentication.swift in Sources */,
 				D887C5CC2BA0AAF700E46174 /* SafariWebView.swift in Sources */,

--- a/Builds/Commands/AccountCommands.swift
+++ b/Builds/Commands/AccountCommands.swift
@@ -36,7 +36,7 @@ struct AccountCommands: Commands {
                 }
                 Divider()
                 Button {
-                    await sceneModel?.signOut()
+                    sceneModel?.signOut()
                 } label: {
                     Text("Sign Out...")
                 }

--- a/Builds/Model/SceneModel.swift
+++ b/Builds/Model/SceneModel.swift
@@ -116,7 +116,7 @@ class SceneModel: ObservableObject, Runnable {
 #endif
     }
 
-    @MainActor func signOut() async {
+    @MainActor func signOut() {
         confirmation = Confirmation(
             "Sign Out",
             message: "Signing out will remove Builds from your GitHub account and clear your favorites from iCloud.",

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -90,29 +90,25 @@ struct MainContentView: View {
             }
         }
         .presents(confirmable: $sceneModel.confirmation)
+#if os(iOS)
+        // iOS relies on sheets, but macOS uses windows so doesn't need this.
         .sheet(item: $sceneModel.sheet) { sheet in
             switch sheet {
             case .add:
                 NavigationStack {
                     WorkflowsContentView(applicationModel: applicationModel)
                 }
-#if os(macOS)
-                .frame(minWidth: 300, minHeight: 300)
-#endif
             case .settings:
                 NavigationView {
-#if os(iOS)
                     PhoneSettingsView()
                         .environmentObject(sceneModel)
-#endif
                 }
             case .logIn:
-#if os(iOS)
                 SafariWebView(url: applicationModel.client.authorizationURL)
                     .ignoresSafeArea()
-#endif
             }
         }
+#endif
         .runs(sceneModel)
         .requestsHigherFrequencyUpdates()
         .environmentObject(sceneModel)

--- a/Builds/Views/PhoneSettingsView.swift
+++ b/Builds/Views/PhoneSettingsView.swift
@@ -69,7 +69,7 @@ struct PhoneSettingsView: View {
             Section {
 
                 Button {
-                    await sceneModel.signOut()
+                    sceneModel.signOut()
                 } label: {
                     Text("Sign Out")
                 }

--- a/Builds/Views/SheetReader.swift
+++ b/Builds/Views/SheetReader.swift
@@ -1,0 +1,87 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+fileprivate class ViewStack {
+
+    var stacks: [String:[UUID]] = [:]
+
+    func push(context: String, id: UUID) {
+        var stack = stacks[context] ?? []
+        stack.append(id)
+        stacks[context] = stack
+    }
+
+    func pop(context: String) {
+        _ = stacks[context]?.popLast()
+    }
+
+    func isTop(context: String, id: UUID) -> Bool {
+        return stacks[context]?.last == id
+    }
+
+}
+
+private struct ViewStackEnvironmentKey: EnvironmentKey {
+    static let defaultValue = ViewStack()
+}
+
+
+extension EnvironmentValues {
+
+    fileprivate var viewStack: ViewStack {
+        get { self[ViewStackEnvironmentKey.self] }
+        set { self[ViewStackEnvironmentKey.self] = newValue }
+    }
+
+}
+
+struct SheetReader<Content: View>: View {
+
+    @Environment(\.viewStack) fileprivate var viewStack
+
+    @State var id = UUID()
+
+    let context: String
+    let content: (Binding<Bool>) -> Content
+
+    init(_ context: String, @ViewBuilder content: @escaping (Binding<Bool>) -> Content) {
+        self.context = context
+        self.content = content
+    }
+
+    var isTop: Binding<Bool> {
+        return Binding {
+            return viewStack.isTop(context: context, id: id)
+        } set: { _ in }
+    }
+
+    var body: some View {
+        content(isTop)
+            .onAppear {
+                viewStack.push(context: context, id: id)
+            }
+            .onDisappear {
+                viewStack.pop(context: context)
+            }
+    }
+
+}


### PR DESCRIPTION
This change addresses the issue where the iPad wasn't displaying the sign out confirmation. It switches to use an alert instead of SwiftUI's built in confirmation dialogs as these present as a popover on iPadOS which doesn't match user expectations in this use-case. Disappointingly, the change also includes a fairly involved approach designed to track the presented sheets to allow us to guarantee the confirmation is always presented from the top-most sheet on all platforms.