### PR TITLE
fix: Show workflow job durations

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D850F4DB2BAA709800CE1796 /* Confirmable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850F4DA2BAA709800CE1796 /* Confirmable.swift */; };
 		D850F4DD2BAA75F900CE1796 /* ConfirmableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850F4DC2BAA75F900CE1796 /* ConfirmableAction.swift */; };
 		D85383552BB4EBB50013F267 /* SingleWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85383542BB4EBB50013F267 /* SingleWindow.swift */; };
+		D85383592BB4F4700013F267 /* WorkflowJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85383582BB4F4700013F267 /* WorkflowJob.swift */; };
 		D85AC0DB2BAE540B003CAE8F /* SummaryCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AC0DA2BAE540B003CAE8F /* SummaryCommands.swift */; };
 		D866F250280350BC00FC6EBB /* PhoneSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D866F24F280350BC00FC6EBB /* PhoneSettingsView.swift */; };
 		D86A91472B9E5FF30008FF63 /* WorkflowInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86A91462B9E5FF30008FF63 /* WorkflowInspector.swift */; };
@@ -121,6 +122,7 @@
 		D850F4DA2BAA709800CE1796 /* Confirmable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Confirmable.swift; sourceTree = "<group>"; };
 		D850F4DC2BAA75F900CE1796 /* ConfirmableAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmableAction.swift; sourceTree = "<group>"; };
 		D85383542BB4EBB50013F267 /* SingleWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleWindow.swift; sourceTree = "<group>"; };
+		D85383582BB4F4700013F267 /* WorkflowJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowJob.swift; sourceTree = "<group>"; };
 		D85AC0DA2BAE540B003CAE8F /* SummaryCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryCommands.swift; sourceTree = "<group>"; };
 		D866F24F280350BC00FC6EBB /* PhoneSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneSettingsView.swift; sourceTree = "<group>"; };
 		D86A91462B9E5FF30008FF63 /* WorkflowInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowInspector.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */,
 				D8CA0EF12B94110A00DAE758 /* TimeInterval.swift */,
 				D8355DD127F674F20091BAFD /* URL.swift */,
+				D85383582BB4F4700013F267 /* WorkflowJob.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				D850F4D92BAA4EA700CE1796 /* PresentsConfirmable.swift in Sources */,
 				D891771B2BA5452F0080B20C /* SummaryPanelViewController.swift in Sources */,
 				D81251B82B929935001F6E85 /* BuildsError.swift in Sources */,
+				D85383592BB4F4700013F267 /* WorkflowJob.swift in Sources */,
 				D8A269B32BAA454100A0E19A /* InspectorCommands.swift in Sources */,
 				D8ADD9932B9EA06800D314F1 /* WorkflowJobsList.swift in Sources */,
 				D87E0D402BB4E52700E94A59 /* WorkflowInspectorModel.swift in Sources */,

--- a/Builds/Extensions/WorkflowJob.swift
+++ b/Builds/Extensions/WorkflowJob.swift
@@ -1,0 +1,33 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension GitHub.WorkflowJob {
+
+    var duration: DateComponents? {
+        let calendar = Calendar(identifier: .gregorian)
+        guard let started_at, let completed_at else {
+            return nil
+        }
+        return calendar.dateComponents([.hour, .minute, .second], from: started_at, to: completed_at)
+    }
+
+}

--- a/Builds/Models/GitHub.swift
+++ b/Builds/Models/GitHub.swift
@@ -116,10 +116,12 @@ class GitHub {
 
         let id: Int
 
+        let completed_at: Date?
         let conclusion: Conclusion?
         let html_url: URL
         let name: String
         let run_id: Int
+        let started_at: Date?
         let status: Status
     }
 

--- a/Builds/Views/WorkflowJobsList.swift
+++ b/Builds/Views/WorkflowJobsList.swift
@@ -22,7 +22,13 @@ import SwiftUI
 
 struct WorkflowJobList: View {
 
-    @Environment(\.openURL) private var openURL
+    static let formatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    @EnvironmentObject private var sceneModel: SceneModel
 
     let jobs: [GitHub.WorkflowJob]
 
@@ -33,13 +39,19 @@ struct WorkflowJobList: View {
     var body: some View {
         ForEach(jobs) { job in
             Button {
-                openURL(job.html_url)
+                sceneModel.openURL(job.html_url)
             } label: {
                 HStack {
                     Image(systemName: "circle.fill")
                         .renderingMode(.template)
                         .foregroundStyle(color(for: job))
                     Text(job.name)
+                    Spacer()
+                    if let duration = job.duration,
+                       let value = Self.formatter.string(from: duration) {
+                        Text(value)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change adds job durations to the inspector and popover. It also fixes a bug where workflow jobs were not correctly opening in the in-app browser on iOS.