### PR TITLE
refactor: Automatically ignore safe areas in `SafariWebView`

### DIFF
--- a/Builds/Modifiers/PresentsURL.swift
+++ b/Builds/Modifiers/PresentsURL.swift
@@ -53,7 +53,6 @@ fileprivate struct URLPresenter<Content: View>: View {
         content
             .sheet(item: binding) { url in
                 SafariWebView(url: url)
-                    .ignoresSafeArea()
             }
     }
 

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -93,7 +93,6 @@ struct MainContentView: View {
                 }
             case .logIn:
                 SafariWebView(url: applicationModel.client.authorizationURL)
-                    .ignoresSafeArea()
             case .view(let id):
                 WorkflowDetailsSheet(id: id)
             }

--- a/Builds/Views/PhoneSettingsView.swift
+++ b/Builds/Views/PhoneSettingsView.swift
@@ -95,7 +95,6 @@ struct PhoneSettingsView: View {
             switch sheet {
             case .managePermissions:
                 SafariWebView(url: applicationModel.client.permissionsURL)
-                    .ignoresSafeArea()
             }
         }
         .dismissable()

--- a/Builds/Views/SafariWebView.swift
+++ b/Builds/Views/SafariWebView.swift
@@ -23,16 +23,31 @@
 import SwiftUI
 import SafariServices
 
-struct SafariWebView: UIViewControllerRepresentable {
-    let url: URL
+struct SafariWebView: View {
 
-    func makeUIViewController(context: Context) -> SFSafariViewController {
-        return SFSafariViewController(url: url)
+    private struct SafariViewControllerRepresentable: UIViewControllerRepresentable {
+        let url: URL
+
+        func makeUIViewController(context: Context) -> SFSafariViewController {
+            return SFSafariViewController(url: url)
+        }
+
+        func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+
+        }
     }
 
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+    private let url: URL
 
+    init(url: URL) {
+        self.url = url
     }
+
+    var body: some View {
+        SafariViewControllerRepresentable(url: url)
+            .ignoresSafeArea()
+    }
+
 }
 
 #endif


### PR DESCRIPTION
This makes the call sites a little cleaner.