### PR TITLE
fix: Rename the 'Manage Workflows' button to 'Add Workflows'

### DIFF
--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -44,6 +44,9 @@
     "Add Branch..." : {
 
     },
+    "Add Workflows" : {
+
+    },
     "Add workflows to view their statuses." : {
 
     },

--- a/Builds/Views/WorkflowsSection.swift
+++ b/Builds/Views/WorkflowsSection.swift
@@ -49,7 +49,7 @@ struct WorkflowsSection: View {
                         Button {
                             sceneModel.manageWorkflows()
                         } label: {
-                            Text("Manage Workflows")
+                            Text("Add Workflows")
                         }
                     }
                 }


### PR DESCRIPTION
The terminology seems to have caused issues for App Review leading to an App Store rejection.