### PR TITLE
fix: Use up-to-date GitHub authentication details from iCloud keychain

### DIFF
--- a/Builds/Commands/AccountCommands.swift
+++ b/Builds/Commands/AccountCommands.swift
@@ -28,7 +28,7 @@ struct AccountCommands: Commands {
 
     var body: some Commands {
         CommandMenu("Account") {
-            if applicationModel.isAuthorized {
+            if applicationModel.isSignedIn {
                 Button {
                     applicationModel.managePermissions()
                 } label: {

--- a/Builds/Commands/LifecycleCommands.swift
+++ b/Builds/Commands/LifecycleCommands.swift
@@ -36,7 +36,7 @@ struct LifecycleCommands: Commands {
                 Text("Refresh...")
             }
             .keyboardShortcut("r")
-            .disabled(!applicationModel.isAuthorized)
+            .disabled(!applicationModel.isSignedIn)
         }
     }
 

--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -314,7 +314,7 @@ class ApplicationModel: NSObject, ObservableObject {
         }
 
         // Get the authentication token.
-        self.accessToken = try await api.authenticate(with: code)
+        accessToken = try await api.authenticate(with: code)
 
         // Indicate that we're signed in.
         isSignedIn = true

--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -132,6 +132,14 @@ class ApplicationModel: NSObject, ObservableObject {
 
     private let api: GitHub
 
+    var authorizationURL: URL {
+        return api.authorizationURL
+    }
+
+    var permissionsURL: URL {
+        return api.permissionsURL
+    }
+
     override init() {
         let configuration = Bundle.main.configuration()
         self.api = GitHub(clientId: configuration.clientId,

--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -327,7 +327,9 @@ class ApplicationModel: NSObject, ObservableObject {
 
     @MainActor func signOut(preserveFavorites: Bool) async {
         do {
-            try await client.deleteGrant()
+            if let accessToken {
+                try await api.deleteGrant(accessToken: accessToken)
+            }
         } catch {
             print("Failed to delete client grant with error \(error).")
         }

--- a/Builds/Models/GitHub.swift
+++ b/Builds/Models/GitHub.swift
@@ -27,6 +27,7 @@ enum GitHubError: Error {
 
 class GitHub {
 
+    // TODO: REMOVE THIS!
     struct Authentication: RawRepresentable {
 
         let accessToken: String
@@ -340,7 +341,7 @@ class GitHub {
         return response
     }
 
-    func authenticate(with code: String) async throws -> Authentication {
+    func authenticate(with code: String) async throws -> String {
         guard let url = url(.accessToken, parameters: [
             "client_id": clientId,
             "client_secret": clientSecret,
@@ -355,10 +356,10 @@ class GitHub {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let accessToken = try decoder.decode(AccessToken.self, from: data)
-        return Authentication(accessToken: accessToken.access_token)
+        return accessToken.access_token
     }
 
-    func deleteGrant(authentication: Authentication) async throws {
+    func deleteGrant(accessToken: String) async throws {
         // This end-point is a little unnusual:
         // https://docs.github.com/en/rest/apps/oauth-applications?apiVersion=2022-11-28#delete-an-app-authorization
         // https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#using-basic-authentication
@@ -379,7 +380,7 @@ class GitHub {
 
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode([
-            "access_token": authentication.accessToken,
+            "access_token": accessToken,
         ])
 
         let (_, response) = try await URLSession.shared.data(for: request)

--- a/Builds/Models/GitHub.swift
+++ b/Builds/Models/GitHub.swift
@@ -27,28 +27,6 @@ enum GitHubError: Error {
 
 class GitHub {
 
-    // TODO: REMOVE THIS!
-    struct Authentication: RawRepresentable {
-
-        let accessToken: String
-
-        init(accessToken: String) {
-            self.accessToken = accessToken
-        }
-
-        init?(rawValue: String) {
-            guard !rawValue.isEmpty else {
-                return nil
-            }
-            self.accessToken = rawValue
-        }
-
-        var rawValue: String {
-            return accessToken
-        }
-
-    }
-
     private struct AccessToken: Codable {
 
         let access_token: String
@@ -279,7 +257,7 @@ class GitHub {
     func workflowRuns(repositoryName: String,
                       page: Int?,
                       perPage: Int?,
-                      authentication: Authentication) async throws -> [WorkflowRun] {
+                      accessToken: String) async throws -> [WorkflowRun] {
         var queryItems: [URLQueryItem] = []
         if let page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
@@ -289,16 +267,16 @@ class GitHub {
         }
         let url = URL(string: "https://api.github.com/repos/\(repositoryName)/actions/runs")!
             .settingQueryItems(queryItems)!
-        let response: WorkflowRuns = try await fetch(url, accessToken: authentication.accessToken)
+        let response: WorkflowRuns = try await fetch(url, accessToken: accessToken)
         return response.workflow_runs
     }
 
     // TODO: Paged fetch
-    func repositories(authentication: Authentication) async throws -> [Repository] {
+    func repositories(accessToken: String) async throws -> [Repository] {
         var repositories: [Repository] = []
         for page in 1... {
             let url = URL(string: "https://api.github.com/user/repos")!
-            let response: [Repository] = try await fetch(url, accessToken: authentication.accessToken, page: page, perPage: 100)
+            let response: [Repository] = try await fetch(url, accessToken: accessToken, page: page, perPage: 100)
             repositories += response
             if response.isEmpty {
                 break
@@ -308,36 +286,38 @@ class GitHub {
     }
 
     // TODO: Owner and repo as parameters.
-    func branches(for repository: Repository, authentication: Authentication) async throws -> [Branch] {
+    func branches(for repository: Repository, accessToken: String) async throws -> [Branch] {
         let url = URL(string: "https://api.github.com/repos/\(repository.full_name)/branches")!
-        let response: [Branch] = try await fetch(url, accessToken: authentication.accessToken)
+        let response: [Branch] = try await fetch(url, accessToken: accessToken)
         return response
     }
 
     // TODO: Use repositoryname
-    func workflows(for repository: Repository, authentication: Authentication) async throws -> [Workflow] {
+    func workflows(for repository: Repository, accessToken: String) async throws -> [Workflow] {
         let url = URL(string: "https://api.github.com/repos/\(repository.full_name)/actions/workflows")!
-        let response: Workflows = try await fetch(url, accessToken: authentication.accessToken)
+        let response: Workflows = try await fetch(url, accessToken: accessToken)
         return response.workflows
     }
 
-    func organizations(authentication: Authentication) async throws -> [Organization] {
+    func organizations(accessToken: String) async throws -> [Organization] {
         let url = URL(string: "https://api.github.com/users/jbmorley/orgs")!
-        let response: [Organization] = try await fetch(url, accessToken: authentication.accessToken)
+        let response: [Organization] = try await fetch(url, accessToken: accessToken)
         return response
     }
 
     func workflowJobs(for repositoryName: String,
                       workflowRun: WorkflowRun,
-                      authentication: Authentication) async throws -> [WorkflowJob] {
+                      accessToken: String) async throws -> [WorkflowJob] {
         let url = URL(string: "https://api.github.com/repos/\(repositoryName)/actions/runs/\(workflowRun.id)/jobs")!
-        let response: WorkflowJobs = try await fetch(url, accessToken: authentication.accessToken)
+        let response: WorkflowJobs = try await fetch(url, accessToken: accessToken)
         return response.jobs
     }
 
-    func annotations(for repositoryName: String, workflowJob: WorkflowJob, authentication: Authentication) async throws -> [Annotation] {
+    func annotations(for repositoryName: String,
+                     workflowJob: WorkflowJob,
+                     accessToken: String) async throws -> [Annotation] {
         let url = URL(string: "https://api.github.com/repos/\(repositoryName)/check-runs/\(workflowJob.id)/annotations")!
-        let response: [Annotation] = try await fetch(url, accessToken: authentication.accessToken)
+        let response: [Annotation] = try await fetch(url, accessToken: accessToken)
         return response
     }
 

--- a/Builds/Models/GitHub.swift
+++ b/Builds/Models/GitHub.swift
@@ -340,27 +340,22 @@ class GitHub {
         return response
     }
 
-    // TODO: This could throw? Might be nicer?
-    func authenticate(with code: String) async -> Result<Authentication, Error> {
-        do {
-            guard let url = url(.accessToken, parameters: [
-                "client_id": clientId,
-                "client_secret": clientSecret,
-                "code": code
-            ]) else {
-                throw GitHubError.invalidUrl
-            }
-            var request = URLRequest(url: url)
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            let (data, response) = try await URLSession.shared.data(for: request)
-            try response.checkHTTPStatusCode()
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let accessToken = try decoder.decode(AccessToken.self, from: data)
-            return .success(Authentication(accessToken: accessToken.access_token))
-        } catch {
-            return .failure(error)
+    func authenticate(with code: String) async throws -> Authentication {
+        guard let url = url(.accessToken, parameters: [
+            "client_id": clientId,
+            "client_secret": clientSecret,
+            "code": code
+        ]) else {
+            throw GitHubError.invalidUrl
         }
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try response.checkHTTPStatusCode()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let accessToken = try decoder.decode(AccessToken.self, from: data)
+        return Authentication(accessToken: accessToken.access_token)
     }
 
     func deleteGrant(authentication: Authentication) async throws {

--- a/Builds/Models/GitHubClient.swift
+++ b/Builds/Models/GitHubClient.swift
@@ -38,14 +38,6 @@ class GitHubClient {
         return api.permissionsURL
     }
 
-    func deleteGrant() async throws {
-        try await api.deleteGrant(accessToken: accessToken)
-    }
-
-    func organizations() async throws -> [GitHub.Organization] {
-        return try await api.organizations(accessToken: accessToken)
-    }
-
     func repositories() async throws -> [GitHub.Repository] {
         return try await api.repositories(accessToken: accessToken)
     }

--- a/Builds/Models/GitHubClient.swift
+++ b/Builds/Models/GitHubClient.swift
@@ -25,9 +25,9 @@ class GitHubClient {
     private let api: GitHub
     private let authentication: GitHub.Authentication
 
-    init(api: GitHub, authentication: GitHub.Authentication) {
+    init(api: GitHub, accessToken: String) {
         self.api = api
-        self.authentication = authentication
+        self.authentication = GitHub.Authentication(accessToken: accessToken)
     }
 
     var authorizationURL: URL {
@@ -39,7 +39,7 @@ class GitHubClient {
     }
 
     func deleteGrant() async throws {
-        try await api.deleteGrant(authentication: authentication)
+        try await api.deleteGrant(accessToken: authentication.accessToken)
     }
 
     func organizations() async throws -> [GitHub.Organization] {

--- a/Builds/Models/GitHubClient.swift
+++ b/Builds/Models/GitHubClient.swift
@@ -30,14 +30,6 @@ class GitHubClient {
         self.accessToken = accessToken
     }
 
-    var authorizationURL: URL {
-        return api.authorizationURL
-    }
-
-    var permissionsURL: URL {
-        return api.permissionsURL
-    }
-
     func repositories() async throws -> [GitHub.Repository] {
         return try await api.repositories(accessToken: accessToken)
     }
@@ -116,11 +108,13 @@ class GitHubClient {
     private func fetchDetails(id: WorkflowInstance.ID,
                               workflowRun: GitHub.WorkflowRun,
                               callback: @escaping (WorkflowInstance) -> Void) async throws {
-        let workflowJobs = try await self.workflowJobs(for: id.repositoryFullName, workflowRun: workflowRun)
+        let workflowJobs = try await api.workflowJobs(for: id.repositoryFullName,
+                                                      workflowRun: workflowRun,
+                                                      accessToken: accessToken)
         var annotations: [WorkflowResult.Annotation] = []
         for workflowJob in workflowJobs {
-            let results = try await self
-                .annotations(for: id.repositoryFullName, workflowJob: workflowJob)
+            let results = try await api
+                .annotations(for: id.repositoryFullName, workflowJob: workflowJob, accessToken: accessToken)
                 .map {
                     return WorkflowResult.Annotation(jobId: workflowJob.id, annotation: $0)
                 }
@@ -141,20 +135,6 @@ class GitHubClient {
 
     func workflows(for repository: GitHub.Repository) async throws -> [GitHub.Workflow] {
         return try await api.workflows(for: repository, accessToken: accessToken)
-    }
-
-    func workflowJobs(for repositoryName: String,
-                      workflowRun: GitHub.WorkflowRun) async throws -> [GitHub.WorkflowJob] {
-        return try await api.workflowJobs(for: repositoryName,
-                                          workflowRun: workflowRun,
-                                          accessToken: accessToken)
-    }
-
-    func annotations(for repositoryName: String,
-                     workflowJob: GitHub.WorkflowJob) async throws -> [GitHub.Annotation] {
-        return try await api.annotations(for: repositoryName,
-                                         workflowJob: workflowJob,
-                                         accessToken: accessToken)
     }
 
 }

--- a/Builds/Models/GitHubClient.swift
+++ b/Builds/Models/GitHubClient.swift
@@ -23,11 +23,11 @@ import SwiftUI
 class GitHubClient {
 
     private let api: GitHub
-    private let authentication: GitHub.Authentication
+    private let accessToken: String
 
     init(api: GitHub, accessToken: String) {
         self.api = api
-        self.authentication = GitHub.Authentication(accessToken: accessToken)
+        self.accessToken = accessToken
     }
 
     var authorizationURL: URL {
@@ -39,15 +39,15 @@ class GitHubClient {
     }
 
     func deleteGrant() async throws {
-        try await api.deleteGrant(accessToken: authentication.accessToken)
+        try await api.deleteGrant(accessToken: accessToken)
     }
 
     func organizations() async throws -> [GitHub.Organization] {
-        return try await api.organizations(authentication: authentication)
+        return try await api.organizations(accessToken: accessToken)
     }
 
     func repositories() async throws -> [GitHub.Repository] {
-        return try await api.repositories(authentication: authentication)
+        return try await api.repositories(accessToken: accessToken)
     }
 
     func workflowRuns(repositoryName: String,
@@ -60,7 +60,7 @@ class GitHubClient {
             let workflowRuns = try await api.workflowRuns(repositoryName: repositoryName,
                                                           page: page,
                                                           perPage: 100,
-                                                          authentication: authentication)
+                                                          accessToken: accessToken)
             let responseWorkflowIds = workflowRuns.map { workflowRun in
                 return WorkflowInstance.ID(repositoryFullName: repositoryName,
                                            workflowId: workflowRun.workflow_id,
@@ -144,25 +144,25 @@ class GitHubClient {
     }
 
     func branches(for repository: GitHub.Repository) async throws -> [GitHub.Branch] {
-        return try await api.branches(for: repository, authentication: authentication)
+        return try await api.branches(for: repository, accessToken: accessToken)
     }
 
     func workflows(for repository: GitHub.Repository) async throws -> [GitHub.Workflow] {
-        return try await api.workflows(for: repository, authentication: authentication)
+        return try await api.workflows(for: repository, accessToken: accessToken)
     }
 
     func workflowJobs(for repositoryName: String,
                       workflowRun: GitHub.WorkflowRun) async throws -> [GitHub.WorkflowJob] {
         return try await api.workflowJobs(for: repositoryName,
                                           workflowRun: workflowRun,
-                                          authentication: authentication)
+                                          accessToken: accessToken)
     }
 
     func annotations(for repositoryName: String,
                      workflowJob: GitHub.WorkflowJob) async throws -> [GitHub.Annotation] {
         return try await api.annotations(for: repositoryName,
                                          workflowJob: workflowJob,
-                                         authentication: authentication)
+                                         accessToken: accessToken)
     }
 
 }

--- a/Builds/Models/GitHubClient.swift
+++ b/Builds/Models/GitHubClient.swift
@@ -55,24 +55,13 @@ class GitHubClient {
         return api.permissionsURL
     }
 
-    func authenticate(with code: String) async throws {
-        let result = await api.authenticate(with: code)
-        try await MainActor.run {
-            switch result {
-            case .success(let authentication):
-                self.authenticationProvider?.authenticationToken = authentication
-            case .failure(let error):
-                self.authenticationProvider?.authenticationToken = nil
-                throw error
-            }
-        }
+    func authenticate(with code: String) async throws -> GitHub.Authentication {
+        return try await api.authenticate(with: code)
     }
 
     func deleteGrant() async throws {
         try await api.deleteGrant(authentication: try getAuthentication())
     }
-
-    // TODO: Wrapper that detects authentication failure.
 
     func organizations() async throws -> [GitHub.Organization] {
         return try await api.organizations(authentication: try getAuthentication())

--- a/Builds/Models/WorkflowsModel.swift
+++ b/Builds/Models/WorkflowsModel.swift
@@ -52,11 +52,11 @@ class WorkflowsModel: ObservableObject, Runnable {
     }
 
     private func updateRepositories() async {
-        let client = await applicationModel.client
-        await MainActor.run {
-            self.isUpdating = true
-        }
         do {
+            let client = try await applicationModel.client
+            await MainActor.run {
+                self.isUpdating = true
+            }
             let repositories = try await client
                 .repositories()
                 .asyncCompactMap { repository -> RepositoryDetails? in

--- a/Builds/Models/WorkflowsModel.swift
+++ b/Builds/Models/WorkflowsModel.swift
@@ -52,7 +52,7 @@ class WorkflowsModel: ObservableObject, Runnable {
     }
 
     private func updateRepositories() async {
-        let client = applicationModel.client
+        let client = await applicationModel.client
         await MainActor.run {
             self.isUpdating = true
         }

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -108,7 +108,7 @@ struct MainContentView: View {
                         .environment(sceneModel)
                 }
             case .logIn:
-                SafariWebView(url: applicationModel.client.authorizationURL)
+                SafariWebView(url: applicationModel.authorizationURL)
             case .view(let id):
                 WorkflowDetailsSheet(id: id)
             }

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -77,12 +77,12 @@ struct MainContentView: View {
                         Label("Manage Workflows", systemImage: "checklist")
                     }
                     .help("Select workflows to display")
-                    .disabled(!applicationModel.isAuthorized)
+                    .disabled(!applicationModel.isSignedIn)
                 }
 
 #if os(macOS)
 
-                if applicationModel.isUpdating || applicationModel.lastError != nil {
+                if applicationModel.isSignedIn && (applicationModel.isUpdating || applicationModel.lastError != nil) {
                     ToolbarItem(id: "status", placement: .navigation) {
                         StatusButton(applicationModel: applicationModel, sceneModel: sceneModel)
                     }

--- a/Builds/Views/PhoneSettingsView.swift
+++ b/Builds/Views/PhoneSettingsView.swift
@@ -94,7 +94,7 @@ struct PhoneSettingsView: View {
         .sheet(item: $sheet) { sheet in
             switch sheet {
             case .managePermissions:
-                SafariWebView(url: applicationModel.client.permissionsURL)
+                SafariWebView(url: applicationModel.permissionsURL)
             }
         }
         .dismissable()

--- a/Builds/Views/PhoneSettingsView.swift
+++ b/Builds/Views/PhoneSettingsView.swift
@@ -71,7 +71,7 @@ struct PhoneSettingsView: View {
                 } label: {
                     Text("Manage GitHub Permissions")
                 }
-                .disabled(!applicationModel.isAuthorized)
+                .disabled(!applicationModel.isSignedIn)
 
             }
 
@@ -82,7 +82,7 @@ struct PhoneSettingsView: View {
                 } label: {
                     Text("Sign Out")
                 }
-                .disabled(!applicationModel.isAuthorized)
+                .disabled(!applicationModel.isSignedIn)
 
             }
 

--- a/Builds/Views/WorkflowMenu.swift
+++ b/Builds/Views/WorkflowMenu.swift
@@ -72,6 +72,7 @@ struct WorkflowMenu {
                 openContext.presentURL(url)
             }
         }
+        .disabled(results.isEmpty)
 
         MenuItem("Open Repository", systemImage: "safari") {
             for url in Set(workflowInstances.compactMap({ $0.repositoryURL })) {

--- a/Builds/Views/WorkflowsSection.swift
+++ b/Builds/Views/WorkflowsSection.swift
@@ -37,7 +37,7 @@ struct WorkflowsSection: View {
 
     var body: some View {
         VStack {
-            if applicationModel.isAuthorized {
+            if applicationModel.isSignedIn {
                 if applicationModel.results.count > 0 {
                     WorkflowsView(workflows: sceneModel.workflows)
                 } else {


### PR DESCRIPTION
This change ensures clients always use the most up-to-date GitHub authentication details from iCloud keychain. Prior to this change it was necessary to relaunch Builds to read the latest settings from iCloud.

Under the hood, this changes to a transient GitHub client instance, reading the authentication token on every new fetch.