### PR TITLE
fix: Higher frequency updates for info windows

### DIFF
--- a/Builds/Views/InfoView.swift
+++ b/Builds/Views/InfoView.swift
@@ -199,6 +199,7 @@ struct InfoView: View {
         }
 #endif
         .dismissable(placement: .cancellationAction)
+        .requestsHigherFrequencyUpdates()
     }
 
 }


### PR DESCRIPTION
This change ensures info windows and sheets always request higher frequency updates so they're kept live even if the main window is closed.