### PR TITLE
fix: Prototype workflow for error recovery

### DIFF
--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -71,6 +71,9 @@
     "Cancel" : {
 
     },
+    "Check GitHub Status" : {
+
+    },
     "Commit" : {
 
     },
@@ -90,6 +93,9 @@
 
     },
     "GitHub" : {
+
+    },
+    "GitHub sometimes encounters incidents which can lead to transient failures. You can check 'GitHub Status' or select 'Refresh' to try again." : {
 
     },
     "Info" : {
@@ -129,6 +135,9 @@
 
     },
     "Refresh" : {
+
+    },
+    "Refresh Error" : {
 
     },
     "Refresh..." : {
@@ -196,6 +205,12 @@
 
     },
     "Signing out will remove Builds from your GitHub account and clear your favorites from iCloud." : {
+
+    },
+    "Simulate Authentication Failure" : {
+
+    },
+    "Simulate Failure" : {
 
     },
     "Summary" : {

--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -394,4 +394,20 @@ class ApplicationModel: NSObject, ObservableObject {
     }
 #endif
 
+#if DEBUG
+
+    enum FailureType {
+        case authentication
+    }
+
+    @MainActor func simulateFailure(_ failureType: FailureType) async {
+        switch failureType {
+        case .authentication:
+            self.accessToken = "fromage"
+        }
+        await refresh()
+    }
+
+#endif
+
 }

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -91,6 +91,22 @@ struct MainContentView: View {
 
 #endif
 
+#if DEBUG
+
+                ToolbarItem(id: "break-auth", placement: .primaryAction) {
+                    Menu {
+                        Button {
+                            await applicationModel.simulateFailure(.authentication)
+                        } label: {
+                            Label("Simulate Authentication Failure", systemImage: "person.slash")
+                        }
+                    } label: {
+                        Label("Simulate Failure", systemImage: "ladybug")
+                    }
+                }
+
+#endif
+
             }
         }
         .presents(confirmable: $sceneModel.confirmation)

--- a/Builds/Views/StatusButton.swift
+++ b/Builds/Views/StatusButton.swift
@@ -82,7 +82,7 @@ struct StatusButton: View {
                 }
 
             } message: {
-                Text(error?.recoveryMessage ?? "")
+                Text(error?.discussion ?? "")
             }
     }
 
@@ -103,7 +103,7 @@ extension Error {
         return false
     }
 
-    var recoveryMessage: String {
+    var discussion: String {
         var lines: [String] = []
         lines.append("\"\(self.localizedDescription)\"")
 


### PR DESCRIPTION
Right now this is limited to macOS as errors are not currently user-visible on iOS. In order to make UX testing during development, this also introduces a debug-only toolbar menu to simulate different error conditions.