### PR TITLE
fix: Remember the selected section and fix a crash on iPad

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		D87390F02BA134D400EFC8B8 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */; };
 		D87E0D3E2BB4E2EC00E94A59 /* PresentsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87E0D3D2BB4E2EC00E94A59 /* PresentsURL.swift */; };
 		D87E0D402BB4E52700E94A59 /* WorkflowInspectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87E0D3F2BB4E52700E94A59 /* WorkflowInspectorModel.swift */; };
+		D87EDA992BBC8EAE00DCCDDB /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87EDA982BBC8EAE00DCCDDB /* Settings.swift */; };
 		D87F23742B6600150085DC12 /* material-icons-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23732B6600150085DC12 /* material-icons-license */; };
 		D87F23762B66006F0085DC12 /* builds-license in Resources */ = {isa = PBXBuildFile; fileRef = D87F23752B66006F0085DC12 /* builds-license */; };
 		D8800B632BB4B25800AD3BB7 /* SheetReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8800B622BB4B25800AD3BB7 /* SheetReader.swift */; };
@@ -149,6 +150,7 @@
 		D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
 		D87E0D3D2BB4E2EC00E94A59 /* PresentsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentsURL.swift; sourceTree = "<group>"; };
 		D87E0D3F2BB4E52700E94A59 /* WorkflowInspectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowInspectorModel.swift; sourceTree = "<group>"; };
+		D87EDA982BBC8EAE00DCCDDB /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		D87F23732B6600150085DC12 /* material-icons-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "material-icons-license"; sourceTree = "<group>"; };
 		D87F23752B66006F0085DC12 /* builds-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "builds-license"; sourceTree = "<group>"; };
 		D8800B622BB4B25800AD3BB7 /* SheetReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetReader.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				D850F4DA2BAA709800CE1796 /* Confirmable.swift */,
 				D850F4DC2BAA75F900CE1796 /* ConfirmableAction.swift */,
 				D850F4D62BAA4E7B00CE1796 /* Confirmation.swift */,
+				D8D3FAF92BB63F16001298CC /* FocusedSceneModel.swift */,
 				D8355DCE27F63B680091BAFD /* GitHub.swift */,
 				D8F0CE0427F89A8100F4EC83 /* GitHubClient.swift */,
 				D83DE3952BB218CB00234B01 /* HTTPStatusCode.swift */,
@@ -364,12 +367,12 @@
 				D8DA9D8A2B97011800C17DBC /* RepositoryDetails.swift */,
 				D8CA0EED2B93E5A600DAE758 /* SceneModel.swift */,
 				D883F1BA2B9803FD00B00F1C /* SectionIdentifier.swift */,
+				D87EDA982BBC8EAE00DCCDDB /* Settings.swift */,
 				D81251B52B918472001F6E85 /* SummaryState.swift */,
 				D87E0D3F2BB4E52700E94A59 /* WorkflowInspectorModel.swift */,
 				D8CA0EF52B942BD900DAE758 /* WorkflowInstance.swift */,
 				D8D413F428045577001BA6C0 /* WorkflowResult.swift */,
 				D8DA9D822B97000F00C17DBC /* WorkflowsModel.swift */,
-				D8D3FAF92BB63F16001298CC /* FocusedSceneModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				D887C5D82BA0B49600E46174 /* SVGImage.swift in Sources */,
 				D8DA9D812B96FFEC00C17DBC /* WorkflowsContentView.swift in Sources */,
 				D88208DB2BB23C030075E9B7 /* HTTPURLResponseError.swift in Sources */,
+				D87EDA992BBC8EAE00DCCDDB /* Settings.swift in Sources */,
 				D8CA0EF42B9412C300DAE758 /* RequestsHigherFrequencyUpdates.swift in Sources */,
 				D86F532A2BB5163100C9A1AF /* PresentURL.swift in Sources */,
 				D854FD872BB616EE00DD31DD /* WorkflowMenu.swift in Sources */,

--- a/Builds/Models/SectionIdentifier.swift
+++ b/Builds/Models/SectionIdentifier.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-enum SectionIdentifier: Identifiable, Hashable {
+enum SectionIdentifier: Identifiable, Hashable, Codable {
 
     var id: String {
         switch self {

--- a/Builds/Models/Settings.swift
+++ b/Builds/Models/Settings.swift
@@ -1,0 +1,119 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+import Interact
+
+class Settings {
+
+    private enum Key: String {
+        case accessToken
+        case favorites
+        case lastUpdate
+        case sceneSettings
+        case status
+        case useInAppBrowser
+    }
+
+    @MainActor private let defaults = KeyedDefaults<Key>()
+    @MainActor private let keychain = KeychainManager<Key>()
+
+    @MainActor var accessToken: String? {
+        get {
+            return try? keychain.string(forKey: .accessToken)
+        }
+        set {
+            try? keychain.set(newValue, forKey: .accessToken)
+        }
+    }
+
+    @MainActor var favorites: [WorkflowInstance.ID] {
+        get {
+            NSUbiquitousKeyValueStore.default.synchronize()
+            guard let data = NSUbiquitousKeyValueStore.default.data(forKey: Key.favorites.rawValue) else {
+                return []
+            }
+            do {
+                return try JSONDecoder().decode([WorkflowInstance.ID].self, from: data)
+            } catch {
+                print("Failed to load favorites with error \(error).")
+            }
+            return []
+        }
+        set {
+            do {
+                let data = try JSONEncoder().encode(newValue)
+                let store = NSUbiquitousKeyValueStore.default
+                guard store.data(forKey: Key.favorites.rawValue) != data else {
+                    return
+                }
+                store.set(data, forKey: Key.favorites.rawValue)
+                store.synchronize()
+            } catch {
+                print("Failed to save favorites with error \(error).")
+            }
+        }
+    }
+
+    @MainActor var lastUpdate: Date? {
+        get {
+            return defaults.object(forKey: .lastUpdate) as? Date
+        }
+        set {
+            defaults.set(newValue, forKey: .lastUpdate)
+        }
+    }
+
+    @MainActor var sceneSettings: SceneModel.Settings {
+        didSet {
+            try? defaults.set(codable: sceneSettings, forKey: .sceneSettings)
+        }
+    }
+
+    @MainActor var cachedStatus: [WorkflowInstance.ID: WorkflowResult] {
+        get {
+            return (try? defaults.codable(forKey: .status)) ?? [:]
+        }
+        set {
+            do {
+                try defaults.set(codable: newValue, forKey: .status)
+            } catch {
+                print("Failed to save status with error \(error).")
+            }
+        }
+    }
+
+    @MainActor var useInAppBrowser: Bool {
+        get {
+            return defaults.bool(forKey: .useInAppBrowser, default: true)
+        }
+        set {
+            defaults.set(newValue, forKey: .useInAppBrowser)
+        }
+    }
+
+    @MainActor init() {
+        // We read and cache some of the settings here to ensure we're not hitting user defaults when creating SwiftUI
+        // models that shadow these values themselves.
+        sceneSettings = (try? defaults.codable(forKey: .sceneSettings)) ?? SceneModel.Settings()
+    }
+
+}

--- a/Builds/Views/MainContentView.swift
+++ b/Builds/Views/MainContentView.swift
@@ -52,7 +52,7 @@ struct MainContentView: View {
                 }
         } detail: {
             VStack {
-                if let section = sceneModel.section {
+                if let section = sceneModel.settings.section {
                     WorkflowsSection(applicationModel: applicationModel, sceneModel: sceneModel, section: section)
                         .id(section)
                 } else {
@@ -64,7 +64,7 @@ struct MainContentView: View {
                 }
             }
             .toolbarTitleDisplayMode(.inline)
-            .navigationTitle(sceneModel.section?.title ?? "")
+            .navigationTitle(sceneModel.settings.section?.title ?? "")
 #if os(macOS)
             .navigationSubtitle("\(sceneModel.workflows.count) Workflows")
 #endif

--- a/Builds/Views/Sidebar.swift
+++ b/Builds/Views/Sidebar.swift
@@ -27,7 +27,7 @@ struct Sidebar: View {
 
     var body: some View {
         @Bindable var sceneModel = sceneModel
-        List(selection: $sceneModel.section) {
+        List(selection: $sceneModel.settings.section) {
             Section {
                 let identifier = SectionIdentifier.all
                 NavigationLink(value: identifier) {


### PR DESCRIPTION
This change moves the settings out into a separate class to avoid bloat in `ApplicationModel` and allow settings to be written directly from `SceneModel` to break a curious SwiftUI Observation loop.