### PR TITLE
fix: Ensure we have access to the apps keychain on macOS

### DIFF
--- a/Builds/Builds.entitlements
+++ b/Builds/Builds.entitlements
@@ -14,13 +14,15 @@
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.uk.co.jbmorley.builds</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)uk.co.jbmorley.builds.apps.appstore</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
It seems like macOS builds loose the default keychain access if you also add app groups. This change adds it explicitly.