### PR TITLE
refactor: Remove some dependence on Combine in `ApplicationModel`

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		D81251B82B929935001F6E85 /* BuildsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81251B72B929935001F6E85 /* BuildsError.swift */; };
 		D81251BA2B929B27001F6E85 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81251B92B929B27001F6E85 /* MainWindow.swift */; };
 		D81251BD2B92A39C001F6E85 /* HandlesAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81251BC2B92A39C001F6E85 /* HandlesAuthentication.swift */; };
+		D81F88A22BC49A7E0038B069 /* Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81F88A12BC49A7E0038B069 /* Summary.swift */; };
 		D820A0A62BC481EB00FDD432 /* BuildsCore in Frameworks */ = {isa = PBXBuildFile; productRef = D820A0A52BC481EB00FDD432 /* BuildsCore */; };
 		D820A0A82BC481F300FDD432 /* BuildsCore in Frameworks */ = {isa = PBXBuildFile; productRef = D820A0A72BC481F300FDD432 /* BuildsCore */; };
 		D820A0AB2BC4867300FDD432 /* OperationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D820A0AA2BC4867300FDD432 /* OperationState.swift */; };
@@ -159,6 +160,7 @@
 		D81251B72B929935001F6E85 /* BuildsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildsError.swift; sourceTree = "<group>"; };
 		D81251B92B929B27001F6E85 /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
 		D81251BC2B92A39C001F6E85 /* HandlesAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlesAuthentication.swift; sourceTree = "<group>"; };
+		D81F88A12BC49A7E0038B069 /* Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Summary.swift; sourceTree = "<group>"; };
 		D820A0A42BC480B000FDD432 /* BuildsCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = BuildsCore; sourceTree = "<group>"; };
 		D820A0AA2BC4867300FDD432 /* OperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationState.swift; sourceTree = "<group>"; };
 		D82E6E712BAB809200536E15 /* Scenes */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Scenes; path = "builds-resources/Scenes"; sourceTree = SOURCE_ROOT; };
@@ -339,6 +341,7 @@
 				D87390EF2BA134D400EFC8B8 /* EdgeInsets.swift */,
 				D8CA0EF12B94110A00DAE758 /* TimeInterval.swift */,
 				D820A0AA2BC4867300FDD432 /* OperationState.swift */,
+				D81F88A12BC49A7E0038B069 /* Summary.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -833,6 +836,7 @@
 				D83929DB2BA367DD0022B4A3 /* Collection.swift in Sources */,
 				D8DA9D892B97009900C17DBC /* WorkflowsPickerModel.swift in Sources */,
 				D883F1B92B98019400B00F1C /* Sidebar.swift in Sources */,
+				D81F88A22BC49A7E0038B069 /* Summary.swift in Sources */,
 				D8D413EF280454AA001BA6C0 /* ApplicationModel.swift in Sources */,
 				D81251BA2B929B27001F6E85 /* MainWindow.swift in Sources */,
 				D883F1BB2B9803FD00B00F1C /* SectionIdentifier.swift in Sources */,


### PR DESCRIPTION
This change continues the work to move away from Combine in `ApplicationModel` to allow us to switch to the new SwiftUI Observation model.