### PR TITLE
fix: Use a stable sort for workflow cells

### DIFF
--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -175,10 +175,14 @@ class ApplicationModel: NSObject, ObservableObject {
             }
             .sorted {
                 let repositoryNameOrder = $0.repositoryName.localizedStandardCompare($1.repositoryName)
-                if repositoryNameOrder == .orderedSame {
-                    return $0.workflowName.localizedStandardCompare($1.workflowName) == .orderedAscending
+                if repositoryNameOrder != .orderedSame {
+                    return repositoryNameOrder == .orderedAscending
                 }
-                return repositoryNameOrder == .orderedAscending
+                let workflowNameOrder = $0.workflowName.localizedStandardCompare($1.workflowName)
+                if workflowNameOrder != .orderedSame {
+                    return workflowNameOrder == .orderedAscending
+                }
+                return $0.id.branch.localizedStandardCompare($1.id.branch) == .orderedAscending
             }
     }
 


### PR DESCRIPTION
This change includes the workflow name and branch in the sort to ensure that workflows within the same repository have a stable flow. It also further tidies up the `ApplicationModel` lifecycle with a view to dropping `ObservableObject` and Combine.