### PR TITLE
refactor: Rename `favorites` to `workflows`

### DIFF
--- a/Builds/Models/SceneModel.swift
+++ b/Builds/Models/SceneModel.swift
@@ -98,12 +98,12 @@ class SceneModel: Runnable {
             message: "Signing out will remove Builds from your GitHub account and clear your workflows from iCloud.",
             actions: [
                 ConfirmableAction("Sign Out", role: .destructive) {
-                    await self.applicationModel.signOut(preserveFavorites: false)
+                    await self.applicationModel.signOut(preserveWorkflows: false)
                     self.settings.sheet = nil
                     self.settings.section = .all
                 },
                 ConfirmableAction("Sign Out and Keep Workflows") {
-                    await self.applicationModel.signOut(preserveFavorites: true)
+                    await self.applicationModel.signOut(preserveWorkflows: true)
                     self.settings.sheet = nil
                     self.settings.section = .all
                 },

--- a/Builds/Views/WorkflowMenu.swift
+++ b/Builds/Views/WorkflowMenu.swift
@@ -141,7 +141,7 @@ struct WorkflowMenu {
                  systemImage: workflowInstances.count == 1 ? "rectangle.slash" : "rectangle.on.rectangle.slash",
                  role: .destructive) {
             for workflowInstance in workflowInstances {
-                applicationModel.removeFavorite(workflowInstance.id)
+                applicationModel.removeWorkflow(workflowInstance.id)
             }
         }
         .disabled(workflowInstances.isEmpty)

--- a/Builds/Views/WorkflowsPicker.swift
+++ b/Builds/Views/WorkflowsPicker.swift
@@ -38,12 +38,12 @@ struct WorkflowPicker: View {
                                      workflowId: workflow.workflowId,
                                      branch: workflow.branch)
         return Binding {
-            return applicationModel.favorites.contains(id)
+            return applicationModel.workflows.contains(id)
         } set: { isOn in
             if isOn {
-                applicationModel.addFavorite(id)
+                applicationModel.addWorkflow(id)
             } else {
-                applicationModel.removeFavorite(id)
+                applicationModel.removeWorkflow(id)
             }
         }
     }

--- a/Builds/Views/WorkflowsPickerModel.swift
+++ b/Builds/Views/WorkflowsPickerModel.swift
@@ -71,10 +71,10 @@ class WorkflowPickerModel: ObservableObject, Runnable {
 
         // Ensure we show branches for all workflows that have been saved.
         applicationModel
-            .$favorites
-            .map { favorites in
-                return favorites.filter { favorite in
-                    favorite.repositoryFullName == self.repositoryDetails.repository.full_name
+            .$workflows
+            .map { workflows in
+                return workflows.filter { workflow in
+                    workflow.repositoryFullName == self.repositoryDetails.repository.full_name
                 }.reduce(into: Set<String>()) { partialResult, id in
                     partialResult.insert(id.branch)
                 }

--- a/BuildsCore/Sources/BuildsCore/Models/GitHubClient.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/GitHubClient.swift
@@ -65,9 +65,9 @@ public class GitHubClient {
     }
 
     // Top level call that triggers fetching all workflow results.
-    public func update(favorites: [WorkflowInstance.ID],
+    public func update(workflows: [WorkflowInstance.ID],
                        callback: @escaping (WorkflowInstance) -> Void) async throws {
-        let repositories = favorites
+        let repositories = workflows
             .reduce(into: [String: [WorkflowInstance.ID]]()) { partialResult, id in
                 var ids = partialResult[id.repositoryFullName] ?? []
                 ids.append(id)

--- a/BuildsCore/Sources/BuildsCore/Models/Settings.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/Settings.swift
@@ -47,7 +47,7 @@ public class Settings {
         }
     }
 
-    @MainActor public var favorites: [WorkflowInstance.ID] {
+    @MainActor public var workflows: [WorkflowInstance.ID] {
         get {
             NSUbiquitousKeyValueStore.default.synchronize()
             guard let data = NSUbiquitousKeyValueStore.default.data(forKey: Key.favorites.rawValue) else {
@@ -56,7 +56,7 @@ public class Settings {
             do {
                 return try JSONDecoder().decode([WorkflowInstance.ID].self, from: data)
             } catch {
-                print("Failed to load favorites with error \(error).")
+                print("Failed to load workflows with error \(error).")
             }
             return []
         }
@@ -70,7 +70,7 @@ public class Settings {
                 store.set(data, forKey: Key.favorites.rawValue)
                 store.synchronize()
             } catch {
-                print("Failed to save favorites with error \(error).")
+                print("Failed to save workflows with error \(error).")
             }
         }
     }


### PR DESCRIPTION
With the exception of the settings key, this change renames `favorites` to `workflows` throughout the app to better match the user-facing model and reduce the cognitive burden of returning to development in the future.