### PR TITLE
refactor: Rename `WorkflowIdentifier` to `WorkflowIdentifierEntity`

### DIFF
--- a/Builds.xcodeproj/project.pbxproj
+++ b/Builds.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D80ED1E32BC5DFFF00897EC7 /* WorkflowQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED1E22BC5DFFF00897EC7 /* WorkflowQuery.swift */; };
-		D80ED1E52BC5E8E400897EC7 /* WorkflowIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED1E42BC5E8E400897EC7 /* WorkflowIdentifier.swift */; };
+		D80ED1E52BC5E8E400897EC7 /* WorkflowIdentifierEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED1E42BC5E8E400897EC7 /* WorkflowIdentifierEntity.swift */; };
 		D80ED1E72BC5EDFB00897EC7 /* SingleWorkflowWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED1E62BC5EDFB00897EC7 /* SingleWorkflowWidget.swift */; };
 		D80ED1E92BC5F14E00897EC7 /* AllWorkflowsTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED1E82BC5F14E00897EC7 /* AllWorkflowsTimelineProvider.swift */; };
 		D80ED1EB2BC5F3ED00897EC7 /* AllWorkflowsTimelineEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED1EA2BC5F3ED00897EC7 /* AllWorkflowsTimelineEntry.swift */; };
@@ -153,7 +153,7 @@
 /* Begin PBXFileReference section */
 		D8092EFF2B698E9F00FD21C8 /* Builds.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Builds.entitlements; sourceTree = "<group>"; };
 		D80ED1E22BC5DFFF00897EC7 /* WorkflowQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowQuery.swift; sourceTree = "<group>"; };
-		D80ED1E42BC5E8E400897EC7 /* WorkflowIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowIdentifier.swift; sourceTree = "<group>"; };
+		D80ED1E42BC5E8E400897EC7 /* WorkflowIdentifierEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowIdentifierEntity.swift; sourceTree = "<group>"; };
 		D80ED1E62BC5EDFB00897EC7 /* SingleWorkflowWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleWorkflowWidget.swift; sourceTree = "<group>"; };
 		D80ED1E82BC5F14E00897EC7 /* AllWorkflowsTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllWorkflowsTimelineProvider.swift; sourceTree = "<group>"; };
 		D80ED1EA2BC5F3ED00897EC7 /* AllWorkflowsTimelineEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllWorkflowsTimelineEntry.swift; sourceTree = "<group>"; };
@@ -301,7 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				D85677FA2BC1CFF6003D2DB6 /* ConfigurationAppIntent.swift */,
-				D80ED1E42BC5E8E400897EC7 /* WorkflowIdentifier.swift */,
+				D80ED1E42BC5E8E400897EC7 /* WorkflowIdentifierEntity.swift */,
 				D80ED1E22BC5DFFF00897EC7 /* WorkflowQuery.swift */,
 			);
 			path = Intents;
@@ -765,7 +765,7 @@
 				D80ED1E72BC5EDFB00897EC7 /* SingleWorkflowWidget.swift in Sources */,
 				D88AFD762BC4967A0060B5CC /* SingleWorkflowTimelineEntry.swift in Sources */,
 				D85677F92BC1CFF6003D2DB6 /* AllWorkflowsWidget.swift in Sources */,
-				D80ED1E52BC5E8E400897EC7 /* WorkflowIdentifier.swift in Sources */,
+				D80ED1E52BC5E8E400897EC7 /* WorkflowIdentifierEntity.swift in Sources */,
 				D85677F72BC1CFF6003D2DB6 /* BuildsWidgetBundle.swift in Sources */,
 				D85677FB2BC1CFF6003D2DB6 /* ConfigurationAppIntent.swift in Sources */,
 				D829F8D22BC35E8B00CA10DB /* Rotates.swift in Sources */,

--- a/BuildsWidget/Intents/ConfigurationAppIntent.swift
+++ b/BuildsWidget/Intents/ConfigurationAppIntent.swift
@@ -30,7 +30,7 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static var description = IntentDescription("This is an example widget.")
 
     @Parameter(title: "Workflow")
-    var workflow: WorkflowIdentifier
+    var workflow: WorkflowIdentifierEntity
 }
 
 extension ConfigurationAppIntent {

--- a/BuildsWidget/Intents/WorkflowIdentifierEntity.swift
+++ b/BuildsWidget/Intents/WorkflowIdentifierEntity.swift
@@ -20,22 +20,30 @@
 
 import AppIntents
 
-struct WorkflowIdentifier: AppEntity {
+import BuildsCore
+
+struct WorkflowIdentifierEntity: AppEntity {
 
     var id: String {
-        return "\(repository):\(workflow):\(branch)"
+        return "\(repositoryFullName):\(workflowId):\(branch)"
     }
 
-    let repository: String
-    let workflow: Int
+    let repositoryFullName: String
+    let workflowId: Int
     let branch: String
 
     static var typeDisplayRepresentation: TypeDisplayRepresentation = "Workflow"
     static var defaultQuery = WorkflowQuery()
 
     var displayRepresentation: DisplayRepresentation {
-        return DisplayRepresentation(title: "\(repository)",
-                                     subtitle: "\(workflow) \(branch)")
+        return DisplayRepresentation(title: "\(repositoryFullName)",
+                                     subtitle: "\(workflowId) \(branch)")
+    }
+
+    init(_ id: WorkflowInstance.ID) {
+        self.repositoryFullName = id.repositoryFullName
+        self.workflowId = id.workflowId
+        self.branch = id.branch
     }
 
 }

--- a/BuildsWidget/Intents/WorkflowQuery.swift
+++ b/BuildsWidget/Intents/WorkflowQuery.swift
@@ -28,35 +28,32 @@ struct WorkflowQuery: EntityQuery, EntityStringQuery {
         case summary
     }
 
-    var workflows: [WorkflowIdentifier] {
+    var workflows: [WorkflowIdentifierEntity] {
         get async {
             let settings = await Settings()
             let workflows = await settings.workflowsCache
-            return workflows.map { id in
-                return WorkflowIdentifier(repository: id.repositoryFullName,
-                                          workflow: id.workflowId,
-                                          branch: id.branch)
-            }
+            return workflows
+                .map { WorkflowIdentifierEntity($0) }
         }
     }
 
-    func entities(matching string: String) async throws -> [WorkflowIdentifier] {
+    func entities(matching string: String) async throws -> [WorkflowIdentifierEntity] {
         return await workflows
             .filter { workflowIdentifier in
-                workflowIdentifier.repository.contains(string)
+                workflowIdentifier.repositoryFullName.contains(string)
             }
     }
 
 
-    func entities(for identifiers: [WorkflowIdentifier.ID]) async throws -> [WorkflowIdentifier] {
+    func entities(for identifiers: [WorkflowIdentifierEntity.ID]) async throws -> [WorkflowIdentifierEntity] {
         return await workflows.filter { identifiers.contains($0.id) }
     }
 
-    func suggestedEntities() async throws -> [WorkflowIdentifier] {
+    func suggestedEntities() async throws -> [WorkflowIdentifierEntity] {
         return await workflows
     }
 
-    func defaultResult() async -> WorkflowIdentifier? {
+    func defaultResult() async -> WorkflowIdentifierEntity? {
         return nil
     }
 }

--- a/BuildsWidget/SingleWorkflowTimelineProvider.swift
+++ b/BuildsWidget/SingleWorkflowTimelineProvider.swift
@@ -29,11 +29,11 @@ struct SingleWorkflowTimelineProvider: AppIntentTimelineProvider {
     init() {
     }
 
-    func workflowResult(for workflowIdentifier: WorkflowIdentifier) async -> WorkflowInstance {
+    func workflowResult(for workflowIdentifier: WorkflowIdentifierEntity) async -> WorkflowInstance {
         let settings = await Settings()
         let results = await settings.cachedStatus
-        let id = WorkflowInstance.ID(repositoryFullName: workflowIdentifier.repository,
-                                     workflowId: workflowIdentifier.workflow,
+        let id = WorkflowInstance.ID(repositoryFullName: workflowIdentifier.repositoryFullName,
+                                     workflowId: workflowIdentifier.workflowId,
                                      branch: workflowIdentifier.branch)
         let workflowResult = results[id]
         return WorkflowInstance(id: id, result: workflowResult)


### PR DESCRIPTION
It seems like the magic intent synthesis doesn't work if the intents (or their structs) are defined outside of the target that uses them. This means, for the time being at least, we're stuck with the duplicate struct in the widget target. This change renames that struct (`WorkflowIdentifier`) to `WorkflowIdentifierEntity` to explicitly acknowledge this and renames the properties to match the naming convention of `WorkflowInstance.ID` to make the code a bit more predictable.