### PR TITLE
refactor: Extract `WorkflowInstance.ID` into a standalone `WorkflowIdentifier` struct

### DIFF
--- a/Builds/Views/WorkflowsView.swift
+++ b/Builds/Views/WorkflowsView.swift
@@ -66,7 +66,7 @@ struct WorkflowsView: View, OpenContext {
                 presentURL(result.workflowRun.html_url)
             }
 #else
-            guard let id = selection.first?.id else {
+            guard let id = selection.first else {
                 return
             }
             sceneModel.settings.sheet = .view(id)

--- a/BuildsCore/Sources/BuildsCore/Models/GitHubClient.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/GitHubClient.swift
@@ -71,7 +71,7 @@ public class GitHubClient {
             .reduce(into: [String: [WorkflowInstance.ID]]()) { partialResult, id in
                 var ids = partialResult[id.repositoryFullName] ?? []
                 ids.append(id)
-                partialResult[id.id.repositoryFullName] = ids
+                partialResult[id.repositoryFullName] = ids
             }
         try await repositories.asyncForEach { repository, ids in
             try await self.fetchDetails(repository: repository, ids: ids, callback: callback)

--- a/BuildsCore/Sources/BuildsCore/Models/WorkflowIdentifier.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/WorkflowIdentifier.swift
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public struct WorkflowIdentifier: Hashable, Codable, Sendable {
+
+    public var id: String {
+        return "\(repositoryFullName):\(workflowId):\(branch)"
+    }
+
+    public var organization: String {
+        return String(repositoryFullName.split(separator: "/").first ?? "?")
+    }
+
+    public var repositoryName: String {
+        return String(repositoryFullName.split(separator: "/").last ?? "?")
+    }
+
+    public let repositoryFullName: String
+    public let workflowId: Int
+    public let branch: String
+
+    public init(repositoryFullName: String, workflowId: Int, branch: String) {
+        self.repositoryFullName = repositoryFullName
+        self.workflowId = workflowId
+        self.branch = branch
+    }
+
+}

--- a/BuildsCore/Sources/BuildsCore/Models/WorkflowInstance.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/WorkflowInstance.swift
@@ -22,32 +22,6 @@ import SwiftUI
 
 public struct WorkflowInstance: Identifiable, Hashable {
 
-    public struct ID: Hashable, Codable, Sendable {
-
-        public var id: Self {
-            return self
-        }
-
-        public var organization: String {
-            return String(repositoryFullName.split(separator: "/").first ?? "?")
-        }
-
-        public var repositoryName: String {
-            return String(repositoryFullName.split(separator: "/").last ?? "?")
-        }
-
-        public let repositoryFullName: String
-        public let workflowId: Int
-        public let branch: String
-
-        public init(repositoryFullName: String, workflowId: Int, branch: String) {
-            self.repositoryFullName = repositoryFullName
-            self.workflowId = workflowId
-            self.branch = branch
-        }
-
-    }
-
     public var annotations: [WorkflowResult.Annotation] {
         return result?.annotations ?? []
     }
@@ -143,7 +117,7 @@ public struct WorkflowInstance: Identifiable, Hashable {
         return repositoryURL.appendingPathComponents(["actions", "runs", String(id), "workflow"])
     }
 
-    public let id: ID
+    public let id: WorkflowIdentifier
     public let result: WorkflowResult?
 
     public init(id: ID, result: WorkflowResult? = nil) {


### PR DESCRIPTION
I've gone back and forth on this one. Back to `WorkflowIdentifier`.