### PR TITLE
fix: Make widget text black to match the app

### DIFF
--- a/BuildsWidget/AllWorkflowsWidgetEntryView.swift
+++ b/BuildsWidget/AllWorkflowsWidgetEntryView.swift
@@ -23,6 +23,8 @@ import SwiftUI
 
 struct AllWorkflowsWidgetEntryView : View {
 
+    @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+
     var entry: AllWorkflowsTimelineProvider.Entry
 
     var body: some View {
@@ -44,7 +46,7 @@ struct AllWorkflowsWidgetEntryView : View {
                     .opacity(0.6)
             }
         }
-        .widgetAccentable()
+        .foregroundColor(widgetRenderingMode == .fullColor ? .black : nil)
         .containerBackground(entry.summary.status.color, for: .widget)
     }
 }

--- a/BuildsWidget/SingleWorkflowWidgetEntryView.swift
+++ b/BuildsWidget/SingleWorkflowWidgetEntryView.swift
@@ -23,6 +23,8 @@ import SwiftUI
 
 struct SingleWorkflowWidgetEntryView : View {
 
+    @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+
     var entry: SingleWorkflowTimelineProvider.Entry
 
     var body: some View {
@@ -53,7 +55,7 @@ struct SingleWorkflowWidgetEntryView : View {
                 }
             }
         }
-        .widgetAccentable()
+        .foregroundColor(widgetRenderingMode == .fullColor ? .black : nil)
         .containerBackground(entry.workflowInstance?.statusColor ?? .gray, for: .widget)
     }
 }


### PR DESCRIPTION
This improves legibility in dark mode while ensuring widgets still display correctly when vibrant and accented.