### PR TITLE
fix: Use the default widget background and accent colors

### DIFF
--- a/BuildsWidget/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/BuildsWidget/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,10 +1,6 @@
 {
   "colors" : [
     {
-      "color" : {
-        "platform" : "universal",
-        "reference" : "systemGreenColor"
-      },
       "idiom" : "universal"
     }
   ],

--- a/BuildsWidget/Resources/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/BuildsWidget/Resources/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,10 +1,6 @@
 {
   "colors" : [
     {
-      "color" : {
-        "platform" : "universal",
-        "reference" : "systemGreenColor"
-      },
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
This generally matches the color palette of the app and helps ensure things are legible.