### PR TITLE
fix: Support background updates for the All Workflows widget

### DIFF
--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -138,7 +138,7 @@ class ApplicationModel: NSObject, ObservableObject {
                 print("Refreshing...")
                 self.isUpdating = true
                 self.lastError = nil
-                try await self.client.update(workflows: self.workflows) { [weak self] workflowInstance in
+                _ = try await self.client.update(workflows: self.workflows) { [weak self] workflowInstance in
                     guard let self else {
                         return
                     }
@@ -343,7 +343,7 @@ class ApplicationModel: NSObject, ObservableObject {
 
     func refresh(ids: [WorkflowInstance.ID]) async {
         do {
-            try await client.update(workflows: ids) { [weak self] workflowInstance in
+            _ = try await client.update(workflows: ids) { [weak self] workflowInstance in
                 guard let self else {
                     return
                 }

--- a/BuildsWidget/SingleWorkflowTimelineProvider.swift
+++ b/BuildsWidget/SingleWorkflowTimelineProvider.swift
@@ -48,7 +48,9 @@ struct SingleWorkflowTimelineProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: ConfigurationAppIntent,
                   in context: Context) async -> Timeline<SingleWorkflowTimelineEntry> {
-        guard let workflowResult = try? await GitHubClient.default.fetch(id: configuration.workflow.identifier) else {
+        guard let workflowResult = try? await GitHubClient.default.fetch(id: configuration.workflow.identifier,
+                                                                         options: [])
+        else {
             return Timeline(entries: [placeholder(in: context)], policy: .standard)
         }
         let entry = SingleWorkflowTimelineEntry(workflowInstance: workflowResult,


### PR DESCRIPTION
This includes a drive-by refactor to add a normal async result return path to the `GitHubClient` fetch APIs to make it easier to use them inline.