### PR TITLE
fix: Show workflow names in the Single Workflow widget settings

### DIFF
--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -32,12 +32,6 @@
         }
       }
     },
-    "5 minutes ago" : {
-
-    },
-    "1234567" : {
-
-    },
     "About %@..." : {
 
     },
@@ -120,6 +114,9 @@
 
     },
     "Manage GitHub Permissions..." : {
+
+    },
+    "never" : {
 
     },
     "No Workflows" : {

--- a/Builds/Views/WorkflowInstanceCell.swift
+++ b/Builds/Views/WorkflowInstanceCell.swift
@@ -87,7 +87,7 @@ struct WorkflowInstanceCell: View {
                     Text(instance.workflowName)
                     Text(instance.id.branch)
                         .monospaced()
-                    Text(instance.sha ?? "1234567")
+                    Text(instance.sha ?? "-")
                         .monospaced()
                 }
                 VStack {
@@ -96,12 +96,11 @@ struct WorkflowInstanceCell: View {
                             Text(createdAt, format: .relative(presentation: .numeric))
                         }
                     } else {
-                        Text("5 minutes ago")
+                        Text("never")
                     }
                 }
                 .gridColumnAlignment(.trailing)
             }
-            .redacted(reason: instance.result == nil ? .placeholder : nil)
             .font(.subheadline)
             .opacity(0.6)
         }

--- a/Builds/Views/WorkflowsPicker.swift
+++ b/Builds/Views/WorkflowsPicker.swift
@@ -36,6 +36,7 @@ struct WorkflowPicker: View {
     func binding(for workflow: WorkflowPickerModel.WorkflowDetails) -> Binding<Bool> {
         let id = WorkflowInstance.ID(repositoryFullName: workflowPickerModel.repositoryDetails.repository.full_name,
                                      workflowId: workflow.workflowId,
+                                     workflowNameSnapshot: workflow.workflowName,
                                      branch: workflow.branch)
         return Binding {
             return applicationModel.workflows.contains(id)

--- a/BuildsCore/Sources/BuildsCore/Models/GitHubClient.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/GitHubClient.swift
@@ -75,6 +75,7 @@ public class GitHubClient {
             let responseWorkflowIds = workflowRuns.map { workflowRun in
                 return WorkflowInstance.ID(repositoryFullName: repositoryName,
                                            workflowId: workflowRun.workflow_id,
+                                           workflowNameSnapshot: workflowRun.name,
                                            branch: workflowRun.head_branch)
             }
             workflowIds.formUnion(responseWorkflowIds)
@@ -126,6 +127,7 @@ public class GitHubClient {
             .reduce(into: [WorkflowInstance.ID: GitHub.WorkflowRun]()) { partialResult, workflowRun in
                 let id = WorkflowInstance.ID(repositoryFullName: workflowRun.repository.full_name,
                                              workflowId: workflowRun.workflow_id,
+                                             workflowNameSnapshot: workflowRun.name,
                                              branch: workflowRun.head_branch)
                 guard partialResult[id] == nil else {
                     return

--- a/BuildsCore/Sources/BuildsCore/Models/WorkflowIdentifier.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/WorkflowIdentifier.swift
@@ -36,11 +36,16 @@ public struct WorkflowIdentifier: Hashable, Codable, Sendable {
 
     public let repositoryFullName: String
     public let workflowId: Int
+
+    /// Name of the workflow at the time the identifier was created..
+    public let workflowNameSnapshot: String
+
     public let branch: String
 
-    public init(repositoryFullName: String, workflowId: Int, branch: String) {
+    public init(repositoryFullName: String, workflowId: Int, workflowNameSnapshot: String, branch: String) {
         self.repositoryFullName = repositoryFullName
         self.workflowId = workflowId
+        self.workflowNameSnapshot = workflowNameSnapshot
         self.branch = branch
     }
 

--- a/BuildsCore/Sources/BuildsCore/Models/WorkflowInstance.swift
+++ b/BuildsCore/Sources/BuildsCore/Models/WorkflowInstance.swift
@@ -103,7 +103,7 @@ public struct WorkflowInstance: Identifiable, Hashable {
     }
 
     public var workflowName: String {
-        return result?.workflowRun.name ?? String(id.workflowId)
+        return result?.workflowRun.name ?? id.workflowNameSnapshot
     }
 
     public var workflowURL: URL? {

--- a/BuildsWidget/Intents/WorkflowIdentifierEntity.swift
+++ b/BuildsWidget/Intents/WorkflowIdentifierEntity.swift
@@ -35,7 +35,7 @@ struct WorkflowIdentifierEntity: AppEntity {
 
     var displayRepresentation: DisplayRepresentation {
         return DisplayRepresentation(title: "\(identifier.repositoryFullName)",
-                                     subtitle: "\(identifier.workflowId) \(identifier.branch)")
+                                     subtitle: "\(identifier.workflowNameSnapshot) \(identifier.branch)")
     }
 
     init(_ identifier: WorkflowInstance.ID) {

--- a/BuildsWidget/Resources/Localizable.xcstrings
+++ b/BuildsWidget/Resources/Localizable.xcstrings
@@ -4,6 +4,16 @@
     "%@" : {
 
     },
+    "%@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
     "%lld" : {
 
     },


### PR DESCRIPTION
This change updates `WorkflowIdentifier` to store a cached snapshot of the workflow name at the time the identifier was created. This ensures we always have _something_ to display when looking up the workflow name and prevents us from falling back on the workflow id (which makes no sense to users). Long term, it would be good to store a local cache of workflow names that we can use to provide an updated name.