### PR TITLE
feat: Improved picker for adding workflows

### DIFF
--- a/Builds/Localizable.xcstrings
+++ b/Builds/Localizable.xcstrings
@@ -44,6 +44,9 @@
     "Add Branch..." : {
 
     },
+    "Add Repositories" : {
+
+    },
     "Add Workflows" : {
 
     },

--- a/Builds/Models/ApplicationModel.swift
+++ b/Builds/Models/ApplicationModel.swift
@@ -84,7 +84,7 @@ class ApplicationModel: NSObject, ObservableObject {
     // set isSignedIn to false. This is to avoid explicitly polling for authentication changes when we already have a
     // mechanism which has to poll the GitHub API fairly frequently for updates and means we're not hitting the keychain
     // more than we need to.
-    @MainActor private var client: GitHubClient {
+    @MainActor var client: GitHubClient {
         get throws {
             do {
                 guard let accessToken = settings.accessToken else {


### PR DESCRIPTION
This introduces a prototype picker for adding workflows. It attempts to flatten all the workflows into a outline view which fetches contents lazily as the user expands different sections. Right now, it falls over thanks to SwiftUI limitations.