### PR TITLE
docs(website): Update the website style

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,6 +30,18 @@ footer:
 
 destination: ../_site
 
+toc:
+  ordered_list: true
+
+gfm_admonitions:
+  inject_css: false
+
 defaults:
   - values:
       layout: "page"
+  - scope:
+      path: "docs"
+    values:
+      layout: "documentation"
+      toc: true
+      shows_title: true


### PR DESCRIPTION
docs/_theme:

- 6fa0572 fix: Add footnote style
- 5dbed06 fix: Generate cache-busting URLs for favicons
- 5e8d67d fix: Use the brand color sparingly
- fd50018 fix: Use the brand color for the download button
- 1787e5b fix: Reduce the documentation header font size
- 50b941a fix: Restore brand color on navigation link hover
- 394f194 fix: Tidy up the documentation appearance
- 1ac45de fix: Use the brand color for links
- 6d0e737 fix: Constrain documentation page width
- 106991b fix: Show the table of contents in a grey box
- 5e0e499 fix: Ensure documentation images match the page width
- 50d871a fix: Update admonition appearance
- 88c61d2 fix: Add the missing file_tree plugin required for documentation pages